### PR TITLE
fix(demo): make alternate-calc-models tables show distinct values

### DIFF
--- a/public/demo/sliders/alternate-calc-models.html
+++ b/public/demo/sliders/alternate-calc-models.html
@@ -25,34 +25,35 @@
     <a href="heatmap.html">4. Dynamic heatmap</a>
   </nav>
   <h1>Slider · Alternate Calculation Models</h1>
-  <p>Each table has the same data, but a different formula has been registered for each.
-     Add a row slider — both tables show "Interpolated" + "From equation" side by side.
-     Sliders sync because the row-axis headers match.</p>
+  <p>Each table samples a different formula over the same axes, so values are
+     similar in shape but not identical. Add a row slider — both tables show
+     "Interpolated" + "From equation" side by side. Sliders sync because the
+     row-axis headers match.</p>
 
   <div class="pair">
     <section class="panel">
       <h2>Table A</h2>
-      <p>Formula: <code>0.001·range + 0.05·sl</code></p>
+      <p>Formula: <code>√sl/2 + 30/√range + 1</code></p>
       <table id="tbl-A">
         <tr><th></th>  <th>10</th><th>20</th><th>30</th><th>40</th><th>50</th></tr>
-        <tr><th>1000</th> <td>4.2</td><td>5.1</td><td>5.9</td><td>6.4</td><td>6.7</td></tr>
-        <tr><th>6000</th> <td>3.6</td><td>4.4</td><td>5.0</td><td>5.5</td><td>5.8</td></tr>
-        <tr><th>11000</th><td>3.0</td><td>3.7</td><td>4.2</td><td>4.6</td><td>4.9</td></tr>
-        <tr><th>16000</th><td>2.5</td><td>3.0</td><td>3.5</td><td>3.9</td><td>4.2</td></tr>
-        <tr><th>21000</th><td>2.0</td><td>2.5</td><td>2.9</td><td>3.3</td><td>3.6</td></tr>
+        <tr><th>1000</th> <td>3.5</td><td>4.2</td><td>4.7</td><td>5.1</td><td>5.5</td></tr>
+        <tr><th>6000</th> <td>3.0</td><td>3.6</td><td>4.1</td><td>4.6</td><td>4.9</td></tr>
+        <tr><th>11000</th><td>2.9</td><td>3.5</td><td>4.0</td><td>4.4</td><td>4.8</td></tr>
+        <tr><th>16000</th><td>2.8</td><td>3.5</td><td>4.0</td><td>4.4</td><td>4.8</td></tr>
+        <tr><th>21000</th><td>2.8</td><td>3.4</td><td>3.9</td><td>4.4</td><td>4.7</td></tr>
       </table>
     </section>
 
     <section class="panel">
       <h2>Table B</h2>
-      <p>Formula: <code>√(range/100) − sl/250</code></p>
+      <p>Formula: <code>log₁₀(sl) + 25/√range + 2</code></p>
       <table id="tbl-B">
         <tr><th></th>  <th>10</th><th>20</th><th>30</th><th>40</th><th>50</th></tr>
-        <tr><th>1000</th> <td>4.2</td><td>5.1</td><td>5.9</td><td>6.4</td><td>6.7</td></tr>
-        <tr><th>6000</th> <td>3.6</td><td>4.4</td><td>5.0</td><td>5.5</td><td>5.8</td></tr>
-        <tr><th>11000</th><td>3.0</td><td>3.7</td><td>4.2</td><td>4.6</td><td>4.9</td></tr>
-        <tr><th>16000</th><td>2.5</td><td>3.0</td><td>3.5</td><td>3.9</td><td>4.2</td></tr>
-        <tr><th>21000</th><td>2.0</td><td>2.5</td><td>2.9</td><td>3.3</td><td>3.6</td></tr>
+        <tr><th>1000</th> <td>3.8</td><td>4.1</td><td>4.3</td><td>4.4</td><td>4.5</td></tr>
+        <tr><th>6000</th> <td>3.3</td><td>3.6</td><td>3.8</td><td>3.9</td><td>4.0</td></tr>
+        <tr><th>11000</th><td>3.2</td><td>3.5</td><td>3.7</td><td>3.8</td><td>3.9</td></tr>
+        <tr><th>16000</th><td>3.2</td><td>3.5</td><td>3.7</td><td>3.8</td><td>3.9</td></tr>
+        <tr><th>21000</th><td>3.2</td><td>3.5</td><td>3.6</td><td>3.8</td><td>3.9</td></tr>
       </table>
     </section>
   </div>
@@ -64,8 +65,8 @@
       if (!window.gridSight) return;
       const a = document.getElementById('tbl-A');
       const b = document.getElementById('tbl-B');
-      if (a) window.gridSight.registerFormula(a, (r, s) => 0.001 * r + 0.05 * s);
-      if (b) window.gridSight.registerFormula(b, (r, s) => Math.sqrt(r / 100) - s / 250);
+      if (a) window.gridSight.registerFormula(a, (r, s) => Math.sqrt(s) / 2 + 30 / Math.sqrt(r) + 1);
+      if (b) window.gridSight.registerFormula(b, (r, s) => Math.log10(s) + 25 / Math.sqrt(r) + 2);
     });
   </script>
 </body>


### PR DESCRIPTION
Both tables previously had identical cell data, so the Interpolated readout
was the same in both even though each had a different formula registered.
Replace the formulas with two simple, similar-shaped models and regenerate
each table's data from its respective formula so the demo visibly shows
that alternate calculation models produce similar-but-different results.