### PR TITLE
fix(sliders): match horizontal slider fill to vertical slider

### DIFF
--- a/src/enrichments/slider-styles.ts
+++ b/src/enrichments/slider-styles.ts
@@ -11,11 +11,20 @@ const SLIDER_CSS = `
 [data-gs-slider] { display:flex; align-items:center; gap:8px; padding:4px 6px; font:13px/1.2 system-ui,sans-serif; }
 [data-gs-slider][data-gs-slider-orientation="vertical"] { flex-direction:column; }
 
-/* Horizontal slider — custom-styled. */
+/* Horizontal slider — custom-styled. Fill the left portion up to the thumb
+   so it matches the native fill the vertical slider already shows. The
+   --gs-fill variable (0-100%) is updated by JS on input. */
 [data-gs-slider] input[type="range"],
 th[data-gs-col-slot] input[type="range"] {
   appearance: none; -webkit-appearance: none; outline: none; margin: 0;
-  cursor: pointer; background: #d0d0d0; border-radius: 2px;
+  cursor: pointer; border-radius: 2px;
+  background: linear-gradient(
+    to right,
+    var(--gs-slider-fill-color, #1976d2) 0%,
+    var(--gs-slider-fill-color, #1976d2) var(--gs-fill, 0%),
+    #d0d0d0 var(--gs-fill, 0%),
+    #d0d0d0 100%
+  );
 }
 th[data-gs-col-slot] input[type="range"] { width: 100%; height: 4px; }
 

--- a/src/enrichments/slider.ts
+++ b/src/enrichments/slider.ts
@@ -287,6 +287,13 @@ export function addSlider(table: HTMLTableElement, axis: Axis): GridSightSlider 
   const input = createSliderInput({ id, min, max, initial, axis, ariaLabel });
   const valueSpan = axis === 'col' ? placeColSlider(ctx, input, initial) : placeRowSlider(ctx, input, initial);
 
+  const updateFill = (v: number) => {
+    if (axis !== 'col') return;
+    const pct = max > min ? ((v - min) / (max - min)) * 100 : 0;
+    input.style.setProperty('--gs-fill', `${pct}%`);
+  };
+  updateFill(initial);
+
   // RAF-throttled input handler.
   let pendingValue: number | null = null;
   let scheduled = false;
@@ -298,6 +305,7 @@ export function addSlider(table: HTMLTableElement, axis: Axis): GridSightSlider 
       slider.position = v;
       slider.position01 = (v - min) / (max - min);
       valueSpan.textContent = formatNumber(v);
+      updateFill(v);
       refreshTableReadouts(table);
       persistPosition(id, slider.position01);
       broadcastSync(slider);
@@ -344,6 +352,7 @@ export function addSlider(table: HTMLTableElement, axis: Axis): GridSightSlider 
       slider.position01 = (clamped - min) / (max - min);
       input.value = String(clamped);
       valueSpan.textContent = formatNumber(clamped);
+      updateFill(clamped);
       refreshTableReadouts(table);
       persistPosition(id, slider.position01);
       if (opts?.broadcast !== false) broadcastSync(slider);

--- a/src/ui/slider-control.ts
+++ b/src/ui/slider-control.ts
@@ -64,6 +64,13 @@ export function createSliderControl(opts: SliderControlOptions): SliderControlHa
   input.value = String(clamp(opts.initial, opts.min, opts.max));
   input.setAttribute('aria-label', opts.label);
 
+  const updateFill = (v: number) => {
+    if (opts.axis === 'row') return;
+    const pct = opts.max > opts.min ? ((v - opts.min) / (opts.max - opts.min)) * 100 : 0;
+    input.style.setProperty('--gs-fill', `${pct}%`);
+  };
+  updateFill(parseFloat(input.value));
+
   const readoutInterpolated = document.createElement('span');
   readoutInterpolated.setAttribute('data-gs-slider-readout', 'interpolated');
   readoutInterpolated.setAttribute('aria-live', 'polite');
@@ -127,6 +134,7 @@ export function createSliderControl(opts: SliderControlOptions): SliderControlHa
   const onInputEvent = () => {
     const v = parseFloat(input.value);
     if (!isFinite(v)) return;
+    updateFill(v);
     scheduleInput(v);
   };
 
@@ -166,6 +174,7 @@ export function createSliderControl(opts: SliderControlOptions): SliderControlHa
     ev.preventDefault();
     next = clamp(next, min, max);
     input.value = String(next);
+    updateFill(next);
     scheduleInput(next);
     if (opts.onChange) opts.onChange(next);
   };
@@ -215,6 +224,7 @@ export function createSliderControl(opts: SliderControlOptions): SliderControlHa
     setValue(value: number, options) {
       const v = clamp(value, parseFloat(input.min), parseFloat(input.max));
       input.value = String(v);
+      updateFill(v);
       if (!options?.silent) {
         scheduleInput(v);
       } else {


### PR DESCRIPTION
The vertical row slider uses native rendering and fills the track from
start to thumb, while the custom-styled horizontal column/threshold
slider showed a uniform grey track. Add a linear-gradient fill to
horizontal sliders driven by a `--gs-fill` CSS variable that JS keeps in
sync with the slider value on init, input, keyboard, setValue, and
broadcast-sync updates.