### PR TITLE
Refactor heatmap column cell collection to use row iteration

### DIFF
--- a/src/enrichments/heatmap.ts
+++ b/src/enrichments/heatmap.ts
@@ -156,15 +156,18 @@ function pickColor(value: number, min: number, max: number, colorScale: string[]
 }
 
 function collectColumnCells(table: HTMLTableElement, index: number): { cell: HTMLTableCellElement; value: number }[] {
-  const hasTbody = !!table.querySelector('tbody');
-  const selector = hasTbody
-    ? `tbody tr:not(.gs-header-row) td:nth-child(${index + 1})`
-    : `tr:not(.gs-header-row) td:nth-child(${index + 1})`;
   const out: { cell: HTMLTableCellElement; value: number }[] = [];
-  table.querySelectorAll<HTMLTableCellElement>(selector).forEach(cell => {
+  const rows = Array.from(table.rows).filter(
+    r => !r.hasAttribute('data-gs-injected') && !r.classList.contains('gs-header-row')
+  );
+  // rows[0] is the header row; data rows start at rows[1].
+  for (let i = 1; i < rows.length; i++) {
+    const cells = Array.from(rows[i].cells).filter(c => !c.hasAttribute('data-gs-injected'));
+    const cell = cells[index];
+    if (!cell || cell.tagName.toLowerCase() !== 'td') continue;
     const v = cleanNumericCell(cell.textContent || '');
     if (v !== null) out.push({ cell, value: v });
-  });
+  }
   return out;
 }
 

--- a/src/enrichments/heatmap.ts
+++ b/src/enrichments/heatmap.ts
@@ -175,8 +175,9 @@ function collectRowCells(table: HTMLTableElement, index: number): { cell: HTMLTa
   const out: { cell: HTMLTableCellElement; value: number }[] = [];
   const row = table.querySelector<HTMLTableRowElement>(`tbody tr:nth-child(${index})`);
   if (!row) return out;
-  Array.from(row.cells).forEach((cell, cellIndex) => {
-    if (cellIndex === 0 && cell.closest('th')) return;
+  const cells = Array.from(row.cells).filter(c => !c.hasAttribute('data-gs-injected'));
+  cells.forEach((cell, cellIndex) => {
+    if (cellIndex === 0 && cell.tagName.toLowerCase() === 'th') return;
     const v = cleanNumericCell(cell.textContent || '');
     if (v !== null) out.push({ cell, value: v });
   });


### PR DESCRIPTION
## Summary
Refactored the `collectColumnCells` function in the heatmap enrichment to use direct row iteration instead of CSS selectors, improving robustness and maintainability.

## Key Changes
- Replaced CSS selector-based approach with explicit row and cell iteration using `table.rows`
- Added filtering to exclude rows with `data-gs-injected` attribute and `gs-header-row` class
- Added filtering to exclude cells with `data-gs-injected` attribute
- Added explicit tag name validation to ensure only `<td>` elements are processed
- Simplified logic by removing conditional selector construction based on `<tbody>` presence

## Implementation Details
- Uses `Array.from()` to convert `HTMLCollection` to arrays for easier filtering
- Iterates from index 1 onwards to skip the header row (index 0)
- Validates cell tag names to handle mixed `<td>` and `<th>` elements gracefully
- Maintains the same output structure and numeric value extraction behavior

https://claude.ai/code/session_01ARakZ9qMiNCoTbLZmYofux