### PR TITLE
Replace slider highlight background with directional borders

### DIFF
--- a/src/enrichments/slider-injection.ts
+++ b/src/enrichments/slider-injection.ts
@@ -282,7 +282,13 @@ export function tearDownInjection(
   if (hasAnyAxisSlider) return;
   for (const cell of ctx.table.querySelectorAll<HTMLElement>('[data-gs-rc]')) {
     cell.removeAttribute('data-gs-rc');
-    cell.classList.remove('gs-slider-highlight');
+    cell.classList.remove(
+      'gs-slider-highlight',
+      'gs-slider-highlight-t',
+      'gs-slider-highlight-r',
+      'gs-slider-highlight-b',
+      'gs-slider-highlight-l'
+    );
   }
   ctx.topRow?.parentElement?.removeChild(ctx.topRow);
   ctx.rowSliderCell?.parentElement?.removeChild(ctx.rowSliderCell);

--- a/src/enrichments/slider-injection.ts
+++ b/src/enrichments/slider-injection.ts
@@ -8,6 +8,7 @@
  */
 
 import { parseHeaderNumber } from '../utils/sync-key';
+import { SLIDER_HIGHLIGHT_CLASSES } from './slider-readout';
 
 export type Axis = 'row' | 'col';
 
@@ -282,13 +283,7 @@ export function tearDownInjection(
   if (hasAnyAxisSlider) return;
   for (const cell of ctx.table.querySelectorAll<HTMLElement>('[data-gs-rc]')) {
     cell.removeAttribute('data-gs-rc');
-    cell.classList.remove(
-      'gs-slider-highlight',
-      'gs-slider-highlight-t',
-      'gs-slider-highlight-r',
-      'gs-slider-highlight-b',
-      'gs-slider-highlight-l'
-    );
+    cell.classList.remove(...SLIDER_HIGHLIGHT_CLASSES);
   }
   ctx.topRow?.parentElement?.removeChild(ctx.topRow);
   ctx.rowSliderCell?.parentElement?.removeChild(ctx.rowSliderCell);

--- a/src/enrichments/slider-readout.ts
+++ b/src/enrichments/slider-readout.ts
@@ -22,7 +22,7 @@ export function bracketIndices(headers: number[], x: number): [number, number] |
   return i < 0 ? null : [i, i + 1];
 }
 
-const EDGE_CLASSES = [
+export const SLIDER_HIGHLIGHT_CLASSES = [
   'gs-slider-highlight',
   'gs-slider-highlight-t',
   'gs-slider-highlight-r',
@@ -32,16 +32,18 @@ const EDGE_CLASSES = [
 
 function clearHighlights(table: HTMLTableElement): void {
   for (const cell of table.querySelectorAll<HTMLElement>('.gs-slider-highlight')) {
-    cell.classList.remove(...EDGE_CLASSES);
+    cell.classList.remove(...SLIDER_HIGHLIGHT_CLASSES);
   }
 }
 
-function markEdges(cell: HTMLElement, t: boolean, r: boolean, b: boolean, l: boolean): void {
+interface EdgeFlags { t: boolean; r: boolean; b: boolean; l: boolean }
+
+function markEdges(cell: HTMLElement, edges: EdgeFlags): void {
   cell.classList.add('gs-slider-highlight');
-  if (t) cell.classList.add('gs-slider-highlight-t');
-  if (r) cell.classList.add('gs-slider-highlight-r');
-  if (b) cell.classList.add('gs-slider-highlight-b');
-  if (l) cell.classList.add('gs-slider-highlight-l');
+  if (edges.t) cell.classList.add('gs-slider-highlight-t');
+  if (edges.r) cell.classList.add('gs-slider-highlight-r');
+  if (edges.b) cell.classList.add('gs-slider-highlight-b');
+  if (edges.l) cell.classList.add('gs-slider-highlight-l');
 }
 
 function highlightCellGroup(
@@ -52,7 +54,12 @@ function highlightCellGroup(
   for (let i = 0; i < rPair.length; i++) {
     for (let j = 0; j < cPair.length; j++) {
       const cell = table.querySelector<HTMLElement>(`[data-gs-rc="${rPair[i]}:${cPair[j]}"]`);
-      if (cell) markEdges(cell, i === 0, j === cPair.length - 1, i === rPair.length - 1, j === 0);
+      if (cell) markEdges(cell, {
+        t: i === 0,
+        r: j === cPair.length - 1,
+        b: i === rPair.length - 1,
+        l: j === 0,
+      });
     }
   }
 }
@@ -60,7 +67,12 @@ function highlightCellGroup(
 function highlightRowsOnly(table: HTMLTableElement, rPair: readonly number[]): void {
   for (let i = 0; i < rPair.length; i++) {
     const cells = Array.from(table.querySelectorAll<HTMLElement>(`[data-gs-rc^="${rPair[i]}:"]`));
-    cells.forEach((c, j) => markEdges(c, i === 0, j === cells.length - 1, i === rPair.length - 1, j === 0));
+    cells.forEach((c, j) => markEdges(c, {
+      t: i === 0,
+      r: j === cells.length - 1,
+      b: i === rPair.length - 1,
+      l: j === 0,
+    }));
   }
 }
 
@@ -69,7 +81,12 @@ function highlightColsOnly(table: HTMLTableElement, cPair: readonly number[]): v
   for (let j = 0; j < cPair.length; j++) {
     const suffix = ':' + cPair[j];
     const cells = all.filter(c => (c.getAttribute('data-gs-rc') ?? '').endsWith(suffix));
-    cells.forEach((c, i) => markEdges(c, i === 0, j === cPair.length - 1, i === cells.length - 1, j === 0));
+    cells.forEach((c, i) => markEdges(c, {
+      t: i === 0,
+      r: j === cPair.length - 1,
+      b: i === cells.length - 1,
+      l: j === 0,
+    }));
   }
 }
 

--- a/src/enrichments/slider-readout.ts
+++ b/src/enrichments/slider-readout.ts
@@ -22,10 +22,26 @@ export function bracketIndices(headers: number[], x: number): [number, number] |
   return i < 0 ? null : [i, i + 1];
 }
 
+const EDGE_CLASSES = [
+  'gs-slider-highlight',
+  'gs-slider-highlight-t',
+  'gs-slider-highlight-r',
+  'gs-slider-highlight-b',
+  'gs-slider-highlight-l',
+] as const;
+
 function clearHighlights(table: HTMLTableElement): void {
   for (const cell of table.querySelectorAll<HTMLElement>('.gs-slider-highlight')) {
-    cell.classList.remove('gs-slider-highlight');
+    cell.classList.remove(...EDGE_CLASSES);
   }
+}
+
+function markEdges(cell: HTMLElement, t: boolean, r: boolean, b: boolean, l: boolean): void {
+  cell.classList.add('gs-slider-highlight');
+  if (t) cell.classList.add('gs-slider-highlight-t');
+  if (r) cell.classList.add('gs-slider-highlight-r');
+  if (b) cell.classList.add('gs-slider-highlight-b');
+  if (l) cell.classList.add('gs-slider-highlight-l');
 }
 
 function highlightCellGroup(
@@ -33,30 +49,27 @@ function highlightCellGroup(
   rPair: readonly number[],
   cPair: readonly number[]
 ): void {
-  for (const ri of rPair) {
-    for (const ci of cPair) {
-      const cell = table.querySelector<HTMLElement>(`[data-gs-rc="${ri}:${ci}"]`);
-      if (cell) cell.classList.add('gs-slider-highlight');
+  for (let i = 0; i < rPair.length; i++) {
+    for (let j = 0; j < cPair.length; j++) {
+      const cell = table.querySelector<HTMLElement>(`[data-gs-rc="${rPair[i]}:${cPair[j]}"]`);
+      if (cell) markEdges(cell, i === 0, j === cPair.length - 1, i === rPair.length - 1, j === 0);
     }
   }
 }
 
 function highlightRowsOnly(table: HTMLTableElement, rPair: readonly number[]): void {
-  for (const ri of rPair) {
-    table.querySelectorAll<HTMLElement>(`[data-gs-rc^="${ri}:"]`)
-      .forEach(c => c.classList.add('gs-slider-highlight'));
+  for (let i = 0; i < rPair.length; i++) {
+    const cells = Array.from(table.querySelectorAll<HTMLElement>(`[data-gs-rc^="${rPair[i]}:"]`));
+    cells.forEach((c, j) => markEdges(c, i === 0, j === cells.length - 1, i === rPair.length - 1, j === 0));
   }
 }
 
 function highlightColsOnly(table: HTMLTableElement, cPair: readonly number[]): void {
-  const all = table.querySelectorAll<HTMLElement>('[data-gs-rc]');
-  for (const ci of cPair) {
-    const suffix = ':' + ci;
-    all.forEach(c => {
-      if ((c.getAttribute('data-gs-rc') ?? '').endsWith(suffix)) {
-        c.classList.add('gs-slider-highlight');
-      }
-    });
+  const all = Array.from(table.querySelectorAll<HTMLElement>('[data-gs-rc]'));
+  for (let j = 0; j < cPair.length; j++) {
+    const suffix = ':' + cPair[j];
+    const cells = all.filter(c => (c.getAttribute('data-gs-rc') ?? '').endsWith(suffix));
+    cells.forEach((c, i) => markEdges(c, i === 0, j === cPair.length - 1, i === cells.length - 1, j === 0));
   }
 }
 

--- a/src/enrichments/slider-styles.ts
+++ b/src/enrichments/slider-styles.ts
@@ -68,17 +68,37 @@ td.gs-slider-highlight, th.gs-slider-highlight {
   --gs-hl-r: 0 0 0 0 transparent;
   --gs-hl-b: 0 0 0 0 transparent;
   --gs-hl-l: 0 0 0 0 transparent;
+  --gs-hl-t-halo: 0 0 0 0 transparent;
+  --gs-hl-r-halo: 0 0 0 0 transparent;
+  --gs-hl-b-halo: 0 0 0 0 transparent;
+  --gs-hl-l-halo: 0 0 0 0 transparent;
   box-shadow:
+    inset var(--gs-hl-t-halo),
+    inset var(--gs-hl-r-halo),
+    inset var(--gs-hl-b-halo),
+    inset var(--gs-hl-l-halo),
     inset var(--gs-hl-t),
     inset var(--gs-hl-r),
     inset var(--gs-hl-b),
     inset var(--gs-hl-l);
   transition: box-shadow 80ms linear;
 }
-td.gs-slider-highlight-t, th.gs-slider-highlight-t { --gs-hl-t: 0 3px 0 0 #1976d2; }
-td.gs-slider-highlight-r, th.gs-slider-highlight-r { --gs-hl-r: -3px 0 0 0 #1976d2; }
-td.gs-slider-highlight-b, th.gs-slider-highlight-b { --gs-hl-b: 0 -3px 0 0 #1976d2; }
-td.gs-slider-highlight-l, th.gs-slider-highlight-l { --gs-hl-l: 3px 0 0 0 #1976d2; }
+td.gs-slider-highlight-t, th.gs-slider-highlight-t {
+  --gs-hl-t: 0 6px 0 0 #000;
+  --gs-hl-t-halo: 0 8px 0 0 #fff;
+}
+td.gs-slider-highlight-r, th.gs-slider-highlight-r {
+  --gs-hl-r: -6px 0 0 0 #000;
+  --gs-hl-r-halo: -8px 0 0 0 #fff;
+}
+td.gs-slider-highlight-b, th.gs-slider-highlight-b {
+  --gs-hl-b: 0 -6px 0 0 #000;
+  --gs-hl-b-halo: 0 -8px 0 0 #fff;
+}
+td.gs-slider-highlight-l, th.gs-slider-highlight-l {
+  --gs-hl-l: 6px 0 0 0 #000;
+  --gs-hl-l-halo: 8px 0 0 0 #fff;
+}
 [data-gs-marker] {
   position: absolute; width: 14px; height: 14px; border-radius: 50%;
   border: 2px solid #1976d2; background: rgb(255 255 255 / 40%);

--- a/src/enrichments/slider-styles.ts
+++ b/src/enrichments/slider-styles.ts
@@ -64,41 +64,21 @@ th[data-gs-row-header] { background: #fafafa; }
 th[data-gs-row-slot] { background: #fafafa; }
 [data-gs-injected] { background: #fafafa; }
 td.gs-slider-highlight, th.gs-slider-highlight {
-  --gs-hl-t: 0 0 0 0 transparent;
-  --gs-hl-r: 0 0 0 0 transparent;
-  --gs-hl-b: 0 0 0 0 transparent;
-  --gs-hl-l: 0 0 0 0 transparent;
-  --gs-hl-t-halo: 0 0 0 0 transparent;
-  --gs-hl-r-halo: 0 0 0 0 transparent;
-  --gs-hl-b-halo: 0 0 0 0 transparent;
-  --gs-hl-l-halo: 0 0 0 0 transparent;
-  box-shadow:
-    inset var(--gs-hl-t-halo),
-    inset var(--gs-hl-r-halo),
-    inset var(--gs-hl-b-halo),
-    inset var(--gs-hl-l-halo),
-    inset var(--gs-hl-t),
-    inset var(--gs-hl-r),
-    inset var(--gs-hl-b),
-    inset var(--gs-hl-l);
-  transition: box-shadow 80ms linear;
+  position: relative;
 }
-td.gs-slider-highlight-t, th.gs-slider-highlight-t {
-  --gs-hl-t: 0 6px 0 0 #000;
-  --gs-hl-t-halo: 0 8px 0 0 #fff;
+td.gs-slider-highlight::after, th.gs-slider-highlight::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  box-sizing: border-box;
+  z-index: 10;
+  border: 0 solid #000;
 }
-td.gs-slider-highlight-r, th.gs-slider-highlight-r {
-  --gs-hl-r: -6px 0 0 0 #000;
-  --gs-hl-r-halo: -8px 0 0 0 #fff;
-}
-td.gs-slider-highlight-b, th.gs-slider-highlight-b {
-  --gs-hl-b: 0 -6px 0 0 #000;
-  --gs-hl-b-halo: 0 -8px 0 0 #fff;
-}
-td.gs-slider-highlight-l, th.gs-slider-highlight-l {
-  --gs-hl-l: 6px 0 0 0 #000;
-  --gs-hl-l-halo: 8px 0 0 0 #fff;
-}
+td.gs-slider-highlight-t::after, th.gs-slider-highlight-t::after { border-top-width: 5px; }
+td.gs-slider-highlight-r::after, th.gs-slider-highlight-r::after { border-right-width: 5px; }
+td.gs-slider-highlight-b::after, th.gs-slider-highlight-b::after { border-bottom-width: 5px; }
+td.gs-slider-highlight-l::after, th.gs-slider-highlight-l::after { border-left-width: 5px; }
 [data-gs-marker] {
   position: absolute; width: 14px; height: 14px; border-radius: 50%;
   border: 2px solid #1976d2; background: rgb(255 255 255 / 40%);

--- a/src/enrichments/slider-styles.ts
+++ b/src/enrichments/slider-styles.ts
@@ -73,7 +73,7 @@ td.gs-slider-highlight::after, th.gs-slider-highlight::after {
   pointer-events: none;
   box-sizing: border-box;
   z-index: 10;
-  border: 0 solid #000;
+  border: 0 solid #1976d2;
 }
 td.gs-slider-highlight-t::after, th.gs-slider-highlight-t::after { border-top-width: 5px; }
 td.gs-slider-highlight-r::after, th.gs-slider-highlight-r::after { border-right-width: 5px; }

--- a/src/enrichments/slider-styles.ts
+++ b/src/enrichments/slider-styles.ts
@@ -64,9 +64,21 @@ th[data-gs-row-header] { background: #fafafa; }
 th[data-gs-row-slot] { background: #fafafa; }
 [data-gs-injected] { background: #fafafa; }
 td.gs-slider-highlight, th.gs-slider-highlight {
-  background-color: #ff9 !important;
-  transition: background-color 80ms linear;
+  --gs-hl-t: 0 0 0 0 transparent;
+  --gs-hl-r: 0 0 0 0 transparent;
+  --gs-hl-b: 0 0 0 0 transparent;
+  --gs-hl-l: 0 0 0 0 transparent;
+  box-shadow:
+    inset var(--gs-hl-t),
+    inset var(--gs-hl-r),
+    inset var(--gs-hl-b),
+    inset var(--gs-hl-l);
+  transition: box-shadow 80ms linear;
 }
+td.gs-slider-highlight-t, th.gs-slider-highlight-t { --gs-hl-t: 0 3px 0 0 #1976d2; }
+td.gs-slider-highlight-r, th.gs-slider-highlight-r { --gs-hl-r: -3px 0 0 0 #1976d2; }
+td.gs-slider-highlight-b, th.gs-slider-highlight-b { --gs-hl-b: 0 -3px 0 0 #1976d2; }
+td.gs-slider-highlight-l, th.gs-slider-highlight-l { --gs-hl-l: 3px 0 0 0 #1976d2; }
 [data-gs-marker] {
   position: absolute; width: 14px; height: 14px; border-radius: 50%;
   border: 2px solid #1976d2; background: rgb(255 255 255 / 40%);

--- a/src/style.css
+++ b/src/style.css
@@ -230,17 +230,37 @@ td.gs-slider-highlight {
   --gs-hl-r: 0 0 0 0 transparent;
   --gs-hl-b: 0 0 0 0 transparent;
   --gs-hl-l: 0 0 0 0 transparent;
+  --gs-hl-t-halo: 0 0 0 0 transparent;
+  --gs-hl-r-halo: 0 0 0 0 transparent;
+  --gs-hl-b-halo: 0 0 0 0 transparent;
+  --gs-hl-l-halo: 0 0 0 0 transparent;
   box-shadow:
+    inset var(--gs-hl-t-halo),
+    inset var(--gs-hl-r-halo),
+    inset var(--gs-hl-b-halo),
+    inset var(--gs-hl-l-halo),
     inset var(--gs-hl-t),
     inset var(--gs-hl-r),
     inset var(--gs-hl-b),
     inset var(--gs-hl-l);
   transition: box-shadow 80ms linear;
 }
-td.gs-slider-highlight-t { --gs-hl-t: 0 3px 0 0 #1976d2; }
-td.gs-slider-highlight-r { --gs-hl-r: -3px 0 0 0 #1976d2; }
-td.gs-slider-highlight-b { --gs-hl-b: 0 -3px 0 0 #1976d2; }
-td.gs-slider-highlight-l { --gs-hl-l: 3px 0 0 0 #1976d2; }
+td.gs-slider-highlight-t {
+  --gs-hl-t: 0 6px 0 0 #000;
+  --gs-hl-t-halo: 0 8px 0 0 #fff;
+}
+td.gs-slider-highlight-r {
+  --gs-hl-r: -6px 0 0 0 #000;
+  --gs-hl-r-halo: -8px 0 0 0 #fff;
+}
+td.gs-slider-highlight-b {
+  --gs-hl-b: 0 -6px 0 0 #000;
+  --gs-hl-b-halo: 0 -8px 0 0 #fff;
+}
+td.gs-slider-highlight-l {
+  --gs-hl-l: 6px 0 0 0 #000;
+  --gs-hl-l-halo: 8px 0 0 0 #fff;
+}
 
 
 @media (prefers-color-scheme: light) {

--- a/src/style.css
+++ b/src/style.css
@@ -226,41 +226,21 @@ th[data-gs-row-slot] input[type="range"] {
 }
 
 td.gs-slider-highlight {
-  --gs-hl-t: 0 0 0 0 transparent;
-  --gs-hl-r: 0 0 0 0 transparent;
-  --gs-hl-b: 0 0 0 0 transparent;
-  --gs-hl-l: 0 0 0 0 transparent;
-  --gs-hl-t-halo: 0 0 0 0 transparent;
-  --gs-hl-r-halo: 0 0 0 0 transparent;
-  --gs-hl-b-halo: 0 0 0 0 transparent;
-  --gs-hl-l-halo: 0 0 0 0 transparent;
-  box-shadow:
-    inset var(--gs-hl-t-halo),
-    inset var(--gs-hl-r-halo),
-    inset var(--gs-hl-b-halo),
-    inset var(--gs-hl-l-halo),
-    inset var(--gs-hl-t),
-    inset var(--gs-hl-r),
-    inset var(--gs-hl-b),
-    inset var(--gs-hl-l);
-  transition: box-shadow 80ms linear;
+  position: relative;
 }
-td.gs-slider-highlight-t {
-  --gs-hl-t: 0 6px 0 0 #000;
-  --gs-hl-t-halo: 0 8px 0 0 #fff;
+td.gs-slider-highlight::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  box-sizing: border-box;
+  z-index: 10;
+  border: 0 solid #000;
 }
-td.gs-slider-highlight-r {
-  --gs-hl-r: -6px 0 0 0 #000;
-  --gs-hl-r-halo: -8px 0 0 0 #fff;
-}
-td.gs-slider-highlight-b {
-  --gs-hl-b: 0 -6px 0 0 #000;
-  --gs-hl-b-halo: 0 -8px 0 0 #fff;
-}
-td.gs-slider-highlight-l {
-  --gs-hl-l: 6px 0 0 0 #000;
-  --gs-hl-l-halo: 8px 0 0 0 #fff;
-}
+td.gs-slider-highlight-t::after { border-top-width: 5px; }
+td.gs-slider-highlight-r::after { border-right-width: 5px; }
+td.gs-slider-highlight-b::after { border-bottom-width: 5px; }
+td.gs-slider-highlight-l::after { border-left-width: 5px; }
 
 
 @media (prefers-color-scheme: light) {

--- a/src/style.css
+++ b/src/style.css
@@ -235,7 +235,7 @@ td.gs-slider-highlight::after {
   pointer-events: none;
   box-sizing: border-box;
   z-index: 10;
-  border: 0 solid #000;
+  border: 0 solid #1976d2;
 }
 td.gs-slider-highlight-t::after { border-top-width: 5px; }
 td.gs-slider-highlight-r::after { border-right-width: 5px; }

--- a/src/style.css
+++ b/src/style.css
@@ -226,9 +226,21 @@ th[data-gs-row-slot] input[type="range"] {
 }
 
 td.gs-slider-highlight {
-  background-color: #ff9 !important;
-  transition: background-color 80ms linear;
+  --gs-hl-t: 0 0 0 0 transparent;
+  --gs-hl-r: 0 0 0 0 transparent;
+  --gs-hl-b: 0 0 0 0 transparent;
+  --gs-hl-l: 0 0 0 0 transparent;
+  box-shadow:
+    inset var(--gs-hl-t),
+    inset var(--gs-hl-r),
+    inset var(--gs-hl-b),
+    inset var(--gs-hl-l);
+  transition: box-shadow 80ms linear;
 }
+td.gs-slider-highlight-t { --gs-hl-t: 0 3px 0 0 #1976d2; }
+td.gs-slider-highlight-r { --gs-hl-r: -3px 0 0 0 #1976d2; }
+td.gs-slider-highlight-b { --gs-hl-b: 0 -3px 0 0 #1976d2; }
+td.gs-slider-highlight-l { --gs-hl-l: 3px 0 0 0 #1976d2; }
 
 
 @media (prefers-color-scheme: light) {

--- a/src/style.css
+++ b/src/style.css
@@ -228,6 +228,7 @@ th[data-gs-row-slot] input[type="range"] {
 td.gs-slider-highlight {
   position: relative;
 }
+
 td.gs-slider-highlight::after {
   content: '';
   position: absolute;


### PR DESCRIPTION
## Summary
This change replaces the yellow background highlighting for slider selections with a more sophisticated border-based approach that highlights only the edges of the selected cell range. This provides better visual clarity by showing which edges of the selection are boundaries.

## Key Changes

- **New edge-aware highlighting system**: Introduced `markEdges()` function that applies directional border classes (`gs-slider-highlight-t`, `gs-slider-highlight-r`, `gs-slider-highlight-b`, `gs-slider-highlight-l`) based on cell position within the selection
- **Updated highlight logic**: Modified `highlightCellGroup()`, `highlightRowsOnly()`, and `highlightColsOnly()` to track cell positions and apply appropriate edge classes
- **Centralized class management**: Created `EDGE_CLASSES` constant to maintain a single source of truth for all highlight-related classes
- **Styling overhaul**: Replaced yellow background (`#ff9`) with a border-based approach using `::after` pseudo-elements with 5px blue borders (`#1976d2`)
- **Consistent cleanup**: Updated `clearHighlights()` and `tearDownInjection()` to remove all edge classes when clearing highlights

## Implementation Details

- Edge detection uses array indices: top edge when `i === 0`, right edge when `j === cPair.length - 1`, etc.
- Borders are rendered via `::after` pseudo-elements with `position: absolute` and `inset: 0` to avoid affecting cell layout
- The `::after` approach uses `pointer-events: none` to maintain cell interactivity
- Applied consistently across all three stylesheet files (slider-styles.ts, style.css, and slider-injection.ts cleanup)

https://claude.ai/code/session_01UtykjK48V8k8PLFkWdGETb