### PR TITLE
Add combined specs for row visibility and virtual columns

### DIFF
--- a/specs/002-003-row-visibility/spec.md
+++ b/specs/002-003-row-visibility/spec.md
@@ -1,0 +1,292 @@
+# Feature Specification: Row Visibility & Order (Sort + Filter)
+
+**Feature Branch**: `002-003-row-visibility`
+**Created**: 2026-05-19
+**Status**: Draft
+**Supersedes (planning only, not history)**:
+  [`specs/002-sort/spec.md`](../002-sort/spec.md),
+  [`specs/003-filter/spec.md`](../003-filter/spec.md)
+**Input**: Combine the two column-header lozenges that *together* determine
+the table's visible-row projection: sort (the order rows are shown in) and
+filter (which rows are visible). Both write URL-fragment state with the same
+per-URL-stem scheme as `src/utils/slider-persistence.ts`. Downstream features
+(`005-sparkline`, `008-cumulative-column`, `009-copy-as-csv`,
+`010-diff-compare`) read this projection rather than the raw DOM order, so a
+single shared "visible rows" pipeline is the natural unit of work.
+
+## Why combine
+
+- **Shared contract**: both features answer the same question — *"in what order,
+  and of which rows, do downstream enrichments see the table?"* That contract
+  belongs in one module (`utils/visible-rows.ts`), built once.
+- **Shared infrastructure**: column-header lozenge slot, qualifier rules
+  (`data-gs-ignore`, `rowspan` exclusions), URL persistence shape, restore-on-
+  toggle-off semantics, "directive for missing column → silently dropped"
+  handling, and the lozenge keyboard contract from `ui/header-utils.ts`.
+- **Shared SC envelope**: both features quote the same numbers — 1 000-row tables
+  re-evaluate in under 100 ms, restore within one animation frame, no
+  `localStorage` dependency, byte-identical DOM on toggle-off.
+- **The two interact directly**: a sort over a filtered view, and the
+  cumulative/sparkline/copy/compare features that read "visible rows", all
+  require a single composed pipeline rather than two independent ones with a
+  resolution layer bolted on later.
+
+The two features ship as separate priorities (each is independently valuable),
+but they are designed against one data model and one persistence schema.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Sort a column ascending / descending / off (Priority: P1)
+
+[Carried over from `002-sort` US1.] A user clicks a sort lozenge (**↕**) on a
+column header. The first click sorts ascending; the second descending; the
+third restores the original document order. Only one column drives sort at a
+time.
+
+**Independent Test**: Click the sort lozenge on a numeric column three times
+and verify asc → desc → original. Repeat on a categorical column.
+
+**Acceptance Scenarios**: see `002-sort/spec.md` US1 AS1–AS4 (unchanged).
+
+---
+
+### User Story 2 - Filter a numeric column by range (Priority: P1)
+
+[Carried over from `003-filter` US1.] A filter lozenge (**▽**) on a numeric
+column header opens a popup with **Min** / **Max** number inputs. Out-of-range
+rows are *dimmed* (not removed). Popup closes on outside click or `Escape`;
+filter state survives the close.
+
+**Acceptance Scenarios**: see `003-filter/spec.md` US1 AS1–AS4 (unchanged).
+
+---
+
+### User Story 3 - Filter a categorical column by value list (Priority: P1)
+
+[Carried over from `003-filter` US2.] The filter lozenge on a categorical
+column opens a popup with a count-labelled checkbox list, "select all" /
+"select none", and a type-to-search input.
+
+**Acceptance Scenarios**: see `003-filter/spec.md` US2 AS1–AS3 (unchanged).
+
+---
+
+### User Story 4 - Compose filters across columns, plus a clear-all chip (Priority: P2)
+
+[Carried over from `003-filter` US3.] Multi-column filters compose with logical
+AND. A summary chip lists every active filter as `Column: predicate` with a
+**Clear all filters** affordance.
+
+**Acceptance Scenarios**: see `003-filter/spec.md` US3 AS1–AS3 (unchanged).
+
+---
+
+### User Story 5 - Sort over a filtered view (Priority: P2, **new in the combined spec**)
+
+The user filters "Amount" to `100–500` and then sorts the table by "Amount"
+descending. The sort applies only to the rows that pass the filter — dimmed
+rows do not move into the sorted block. Toggling the filter off restores the
+sort's effect over the full row set in the same direction. Toggling the sort
+off restores the original document order *within the still-filtered view*.
+
+**Why this priority**: Combining sort and filter is the dominant real-world
+workflow ("show me orders over $100, biggest first"). Without explicit rules
+for the composition, downstream features (cumulative running totals, sparkline
+shared scale, copy-as-CSV "current view") would each have to invent their own
+answer.
+
+**Independent Test**: Apply a numeric range filter that dims half the rows.
+Then sort the same column descending. Verify (a) dimmed rows do not move into
+the un-dimmed block, (b) the un-dimmed rows are in descending order, (c)
+clearing the filter shows every row in descending order with no extra click,
+and (d) clearing the sort but keeping the filter restores original document
+order within the un-dimmed set.
+
+**Acceptance Scenarios**:
+
+1. **Given** a filter dims rows `[1, 3]` and a sort is then applied descending
+   on the same column, **When** the sort completes, **Then** rows `[2, 4, 5]`
+   appear in descending order at the top of `tbody` and rows `[1, 3]` remain
+   dimmed in their original positions relative to each other.
+2. **Given** sort is active and a filter is then cleared, **When** the page
+   re-renders, **Then** every row appears in the sort's direction with no
+   user re-interaction.
+3. **Given** sort and filter are both active, **When** the user clicks the
+   sort lozenge to return it to idle, **Then** the un-dimmed rows return to
+   original document order; the filter dimming is unchanged.
+
+---
+
+### User Story 6 - Persist and share the combined view via URL (Priority: P2)
+
+[Carries `002-sort` US2 and `003-filter` US4 together.] Both sort and filter
+state are encoded under one URL-fragment namespace per page, restored before
+content settles, and reproduce 100% on another machine with no `localStorage`
+dependency. Directives referring to missing tables, missing columns, or
+no-longer-present categorical values are silently dropped; surviving
+directives still apply.
+
+**Acceptance Scenarios**: union of `002-sort` US2 AS1–AS2 and `003-filter` US4
+AS1–AS2 (unchanged).
+
+---
+
+### Edge Cases (union of source specs, plus new combinations)
+
+Carried verbatim from the source specs:
+
+- Non-monotonic mixed types in a sort column (`002` Edge Cases).
+- Blank / missing cells under sort and filter (`002`, `003` Edge Cases).
+- Tied sort values (stable sort) (`002` Edge Cases).
+- Multi-section tables — only `tbody` reordered (`002` Edge Cases).
+- `rowspan` / `colspan` on body cells — both lozenges suppressed
+  (`002`, `003` Edge Cases).
+- Categorical column with many distinct values (`003` Edge Cases).
+- Empty-cells default policy and per-popup "Hide empty cells" toggle
+  (`003` Edge Cases).
+- Zero-match filter empty-state message (`003` Edge Cases).
+- Opt-out attributes: `data-gs-ignore`, `data-gs-no-sort`, `data-gs-no-filter`.
+- Toggling Grid-Sight off restores original order and full opacity; URL state
+  remains so toggling back on re-applies both (`002`, `003` Edge Cases).
+
+New / clarified combination cases:
+
+- **Sort interaction with active filter**: Sort operates on the visible
+  (un-dimmed) row block only. Dimmed rows remain in their original-document
+  position within the body and are never lifted into the visible block by a
+  sort. (Resolves a question both source specs left implicit.)
+- **Filter empty-state during sort**: When sort is active and a filter then
+  matches zero rows, the empty-state message from `003` US3 takes precedence
+  over the sort indicator (the sort is still in effect, but no rows are
+  visible to demonstrate it).
+- **Restore order**: "Original document order" is captured **once**, at first
+  enrichment activation per table, before any sort or filter has been applied.
+  Subsequent toggle-off / toggle-on cycles restore against that snapshot.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+The combined requirements set is the union of `002-sort` FR-001..FR-016 and
+`003-filter` FR-001..FR-026, *with the following additions and reconciliations*:
+
+**Visible-row pipeline (new)**
+
+- **FR-VP-001**: Grid-Sight MUST maintain, per table, a derived **Visible Row
+  Sequence**: the ordered list of `tbody` rows after applying (a) the active
+  filter set (dimming, not removal) and (b) the active single-column sort.
+- **FR-VP-002**: The Visible Row Sequence MUST be exposed via a stable internal
+  API (`utils/visible-rows.ts`) returning `{ row: HTMLTableRowElement,
+  dimmed: boolean, sourceIndex: number }[]`. This API is the *only* way
+  downstream enrichments (sparkline, cumulative-column, copy-as-CSV,
+  diff-compare) MAY read row order or visibility.
+- **FR-VP-003**: The pipeline MUST emit a synchronous change event whenever
+  its output changes, so downstream enrichments re-render within one
+  animation frame (carries `008` SC-005).
+- **FR-VP-004**: Sort operates only on rows where `dimmed = false`; dimmed
+  rows retain their `sourceIndex` position and are never re-ordered by sort.
+- **FR-VP-005**: The Original Order Record (from `002` Key Entities) MUST be
+  captured the first time either sort or filter activates on a table, not the
+  first time sort activates alone.
+
+**URL persistence shape (reconciled)**
+
+- **FR-VP-006**: Sort and filter share a single per-page URL-fragment
+  namespace. Each table gets one directive object with optional `sort` and
+  `filters` fields, e.g.
+  `{ table: "<id>", sort?: { column, dir }, filters?: [...] }`.
+- **FR-VP-007**: A URL directive's `sort` block MUST be applied *after* its
+  `filters` block, mirroring the runtime order, so a sort-of-filtered-view is
+  reproduced identically on load.
+- **FR-VP-008**: Restoration MUST complete before the user sees content settle
+  (one animation frame after first paint — combined SC).
+
+**Carried from the source specs (unchanged numbering may be renormalised at
+plan time)**
+
+- Sort affordance and behaviour: `002-sort/spec.md` FR-001..FR-009, plus
+  FR-013..FR-016. Re-clarified per FR-VP-004 to operate on the un-dimmed
+  block.
+- Filter affordance, numeric / categorical popups, composition, chip, empty
+  state: `003-filter/spec.md` FR-001..FR-016.
+- Filter persistence (numeric bounds, ticked values, "Hide empty" choice):
+  `003-filter/spec.md` FR-017..FR-019, subsumed by FR-VP-006.
+- Sort persistence (per-page, missing-column drop): `002-sort/spec.md`
+  FR-010..FR-012, subsumed by FR-VP-006.
+- Accessibility: `002-sort` FR-013/FR-014 (`aria-sort`, next-action accessible
+  name) and `003-filter` FR-020..FR-023 (`aria-pressed`, focus-trap, chip
+  reachable, dimmed rows remain announced) apply in full.
+- Integration / opt-outs: `002-sort` FR-015/FR-016 and `003-filter`
+  FR-024..FR-026.
+
+### Key Entities
+
+- **Sort Directive** (from `002`): `(table, column, direction ∈ {asc, desc})`
+  with at most one per table.
+- **Filter Predicate** (from `003`): numeric range or categorical inclusion
+  set per `(table, column)`.
+- **Active Filter Set** (from `003`): all predicates on a table, composed with
+  AND.
+- **Visible Row Sequence** (new, shared): the ordered, dim-flagged projection
+  of `tbody` rows. Output of the pipeline; input to every downstream feature.
+- **Original Order Record** (reconciled): one snapshot per table, captured at
+  first activation of either sort or filter.
+- **Persisted View State** (new): single per-page URL serialisation containing
+  both sort and filter directives.
+
+## Success Criteria *(mandatory)*
+
+The combined feature inherits every measurable outcome from both source specs.
+Where the two specs quoted equivalent numbers, the combined number is the
+*max* (i.e. the budget covers the combined re-evaluation).
+
+- **SC-001**: A user can sort a column in **two clicks or fewer**, and apply
+  a numeric range filter in **three interactions or fewer**, from a
+  Grid-Sight-enabled page. (Union of `002` SC-001, `003` SC-001.)
+- **SC-002**: For tables up to 1 000 rows, a sort *or* filter change *or* a
+  combined re-evaluation (filter then sort) MUST update the visible row order
+  in **under 100 ms** on a mid-range laptop.
+- **SC-003**: Re-opening a URL containing any combination of sort and filter
+  directives MUST restore the view with no visible flash beyond **one
+  animation frame** after first paint.
+- **SC-004**: A shared URL MUST reproduce on another machine **100% of the
+  time** with no `localStorage` dependency.
+- **SC-005**: Toggling Grid-Sight off MUST restore the table to a
+  **byte-identical DOM** to the pre-enrichment state (excluding GS-injected
+  nodes anywhere on the page).
+- **SC-006 (new)**: With sort and filter both active, downstream consumers
+  reading via `utils/visible-rows.ts` MUST see the exact same row order and
+  dim-flag set as the rendered DOM, verified by an automated parity check in
+  the test suite.
+
+## Assumptions
+
+Union of source specs, with the following additions:
+
+- **Pipeline ordering is filter-then-sort, always**. There is no user-exposed
+  knob to invert this.
+- **Dim, not hide**, as in `003`. Sort never lifts dimmed rows into the
+  visible block.
+- **Single-column sort** in v1 (`002`). Multi-key sort and per-column custom
+  comparators remain out of scope.
+- **AND-only composition** across filters (`003`). Per-column OR within a
+  categorical checkbox list is the only OR semantics.
+- **No new runtime dependency**. Comparison uses platform `Array.prototype.sort`
+  and `Intl.Collator`; filtering uses platform `Number`, `String.prototype.trim`,
+  and `Intl.Collator` where needed.
+- **One URL-fragment namespace per table**, holding both sort and filter under
+  a single directive object (FR-VP-006). The exact key shape is finalised
+  during `/speckit-plan`.
+
+## Implementation Streaming
+
+Even though the two features ship as separate priorities, both are designed
+against this single spec so that:
+
+- The visible-row pipeline lands first as a thin scaffold returning the
+  identity projection (no sort, no filter), with the public API frozen.
+- US1 (sort) and US2/US3 (filter) can then be implemented in parallel by
+  different workers, each plugging into the pipeline.
+- US4 (filter chip / compose) and US5 (sort-over-filter) close out the
+  combination semantics.
+- US6 (URL persistence) lands as a single PR covering both directive shapes.

--- a/specs/005-008-010-virtual-columns/spec.md
+++ b/specs/005-008-010-virtual-columns/spec.md
@@ -1,0 +1,404 @@
+# Feature Specification: Virtual Columns (Sparkline + Cumulative + Compare-Column)
+
+**Feature Branch**: `005-008-010-virtual-columns`
+**Created**: 2026-05-19
+**Status**: Draft
+**Supersedes (planning only, not history)**:
+  [`specs/005-sparkline/spec.md`](../005-sparkline/spec.md),
+  [`specs/008-cumulative-column/spec.md`](../008-cumulative-column/spec.md),
+  [the column-compare half of `specs/010-diff-compare/spec.md`](../010-diff-compare/spec.md)
+**Input**: Combine the three features that append derived columns to the right
+edge of a table. Each appends one or more `<th>` / `<td>` cells, must coexist
+with the others in a defined order, must clean up on Grid-Sight-off, must
+register itself with `009-copy-as-csv`'s "include GS virtual columns" toggle,
+and must follow the visible-row pipeline from
+`002-003-row-visibility`. Most of the work is the shared scaffold; each
+feature's own contribution is a small per-cell renderer.
+
+## Why combine
+
+- **Same DOM operation**: append-only `<th>` in `<thead>` plus one appended
+  `<td>` per body row, with `<tfoot>` getting empty appended cells for column
+  alignment. Already mandated identically by `005` FR-004, `008` FR-007, and
+  `010` FR-011/FR-012.
+- **Same lifecycle**: activate → render → re-render on visible-row changes →
+  detach → leave byte-identical DOM. Quoted identically by all three SC sets.
+- **Same ordering problem**: `008` Edge Cases already specify "cumulative
+  first, sparkline last"; `010` FR-012 says the compare column "MUST coexist
+  with cumulative and sparkline columns per their ordering rules". The
+  ordering belongs to the scaffold, not each feature.
+- **Same persistence shape**: all three encode per-table directives under the
+  shared URL-fragment scheme; reload precedes content-settle by one animation
+  frame.
+- **Same numeric-column detector**: all three reuse the heatmap/statistics
+  detector. Defining the dependency once removes three independent
+  "what counts as numeric" answers.
+- **Same downstream consumer**: `009-copy-as-csv`'s "include GS virtual
+  columns" toggle needs a single registry to enumerate, not three.
+
+Each feature still ships as an independent priority and can be removed without
+affecting the others. The combined spec defines the *scaffold* explicitly and
+references each feature's own renderer through it.
+
+The row-compare half of `010-diff-compare` is **not** part of this combined
+spec — it renders an appended row, not an appended column, and stays in
+`010-diff-compare/spec.md`.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Append a running-sum column (Priority: P1)
+
+[Carried from `008-cumulative-column` US1.] A Σ lozenge on a numeric column
+header appends a "Σ <header>" column on the right. Second click cycles to
+percent-of-total. Third click removes it.
+
+**Acceptance Scenarios**: see `008-cumulative-column/spec.md` US1 AS1–AS4.
+
+---
+
+### User Story 2 - Append a row sparkline column (Priority: P1)
+
+[Carried from `005-sparkline` US1.] A ⌇ lozenge in the table's corner cluster
+appends a "Trend" column rendering an inline SVG mini-bar-chart per row across
+the table's numeric body columns.
+
+**Acceptance Scenarios**: see `005-sparkline/spec.md` US1 AS1–AS3.
+
+---
+
+### User Story 3 - Append a column-comparison column (Priority: P2)
+
+[Carried from `010-diff-compare` US2.] In compare mode, picking column A then
+column B appends a "Δ <colB> − <colA>" column on the right edge with per-row
+deltas.
+
+**Acceptance Scenarios**: see `010-diff-compare/spec.md` US2 AS1–AS2.
+
+---
+
+### User Story 4 - Sparkline hover, focus, tooltip, header highlight (Priority: P2)
+
+[Carried from `005-sparkline` US2.] Sparkline cells are focusable; hover or
+focus shows a tooltip (min/max/last) and highlights the source-column
+headers.
+
+**Acceptance Scenarios**: see `005-sparkline/spec.md` US2 AS1–AS3.
+
+---
+
+### User Story 5 - Sparkline per-row vs shared scaling (Priority: P2)
+
+[Carried from `005-sparkline` US3.] A mode toggle near the "Trend" header
+flips between per-row (default) and shared scaling. The state is persisted.
+
+**Acceptance Scenarios**: see `005-sparkline/spec.md` US3 AS1–AS3.
+
+---
+
+### User Story 6 - Multiple virtual columns coexist in a defined order (Priority: P2, **new in the combined spec**)
+
+The user activates a cumulative column on "Weight", then a cumulative column
+on "Cost" (percent-of-total mode), then the sparkline column, then a
+column-compare overlay between "Q1" and "Q4". The appended columns appear, in
+left-to-right order:
+
+1. Every cumulative column, in activation order;
+2. The column-compare column (at most one);
+3. The sparkline column (at most one — always last).
+
+Removing any virtual column leaves the others in their previous positions.
+
+**Why this priority**: The three features explicitly cross-reference each
+other on ordering. Without one spec defining the order, each ordering rule
+ends up in the wrong feature's edge-cases section, and the inevitable fourth
+appendable feature has to amend three specs at once.
+
+**Independent Test**: Activate three cumulative columns, the sparkline, and
+the column-compare overlay. Confirm the appended column order is
+`[Σ A, Σ B, Σ C, Δ, Trend]`. Remove Σ B; confirm the order becomes
+`[Σ A, Σ C, Δ, Trend]` with no other reflow.
+
+**Acceptance Scenarios**:
+
+1. **Given** two cumulative columns (`Σ Weight`, `Σ Cost`) are active in that
+   order, **When** the user activates the sparkline column, **Then** the
+   appended columns read left-to-right `[Σ Weight, Σ Cost, Trend]`.
+2. **Given** the above plus an active column-compare overlay between two
+   numeric columns, **When** the user inspects the DOM, **Then** the appended
+   columns read left-to-right `[Σ Weight, Σ Cost, Δ, Trend]`.
+3. **Given** the above ordering, **When** the user removes `Σ Weight`,
+   **Then** the appended columns read left-to-right `[Σ Cost, Δ, Trend]` with
+   no other column moving more than the single position vacated.
+
+---
+
+### User Story 7 - Persist and share every appended column via URL (Priority: P2)
+
+[Combines `005-sparkline` US4, `008-cumulative-column` US2 (persistence
+half), and `010-diff-compare` FR-017 column-mode portion.] All virtual-column
+directives are encoded in the URL fragment under a single per-page namespace
+and reproduce on another machine 100% of the time, restored within one
+animation frame.
+
+**Acceptance Scenarios**: union of `005` US4 AS1–AS2, `008` US2 AS1–AS3,
+`010` AS5 (column-mode subset).
+
+---
+
+### User Story 8 - Cooperate with the visible-row pipeline (Priority: P2, **new in the combined spec**)
+
+[Reconciles `005` FR-024/FR-025, `008` FR-011, `010` FR-015/FR-016.] When the
+visible-row pipeline from `002-003-row-visibility` emits a change event:
+
+- The sparkline `<td>` for each row follows the row to its new position; in
+  shared-scale mode, the scale is recomputed over the currently un-dimmed
+  rows.
+- Every cumulative column recomputes over the new Visible Row Sequence
+  (dimmed rows excluded from accumulation).
+- A column-compare overlay is unaffected by row order; if it consumes per-row
+  values, it walks the Visible Row Sequence so the overlay column aligns row-
+  for-row with the source body.
+
+**Independent Test**: Sort a table with all three virtual columns active.
+Verify (a) sparkline cells move with their rows, (b) cumulative values update
+to reflect the new order, (c) the compare column's per-row delta cells move
+with their source rows.
+
+**Acceptance Scenarios**:
+
+1. **Given** sparkline + cumulative + compare columns are active and a sort
+   directive then fires, **When** the sort completes, **Then** all appended
+   cells in each row move with their row and recompute (if order-dependent)
+   within one animation frame.
+2. **Given** a filter then dims half the rows, **When** the dim event
+   propagates, **Then** cumulative columns exclude dimmed rows from
+   accumulation and the shared-scale sparkline window recomputes over the
+   un-dimmed subset.
+
+---
+
+### Edge Cases (union of source specs, plus new combinations)
+
+Carried verbatim from source specs:
+
+- Sparkline qualifier: `≥ 3 predominantly-numeric body columns` (`005` FR-002).
+- Sparkline incomplete row → em-dash placeholder (`005` FR-009).
+- Sparkline zero-range row → flat baseline (`005` Edge Cases).
+- Cumulative non-numeric cells skipped, virtual cell rendered blank
+  (`008` FR-012).
+- Cumulative + sparkline ordering (`008` Edge Cases) — promoted to US6.
+- Compare non-numeric operand → "—" placeholder (`010` FR-009).
+- Compare zero divisor for percent (`010` FR-010).
+- `data-gs-ignore`, `data-gs-no-sparkline`, `data-gs-no-cumulative`,
+  `data-gs-no-compare` opt-outs (all three specs).
+- Toggle Grid-Sight off → all appended cells removed, byte-identical DOM
+  (all three specs' SC-005-equivalents).
+- `colgroup` / `col` declarations do not apply to appended columns
+  (`005` Edge Cases) — generalised in the scaffold.
+- `rowspan` / `colspan` on source body cells suppress the offering
+  (`008` Edge Cases).
+
+New / clarified combination cases:
+
+- **Order conflict**: if a URL directive describes an activation order that
+  would violate US6 (e.g. sparkline before cumulative), the scaffold MUST
+  re-apply the canonical order on restore and emit no error.
+- **Removing a cumulative column mid-list**: documented in US6 AS3.
+- **Visible-row pipeline change events fire once per frame**: all virtual
+  columns subscribe to the same event source and re-render in dependency
+  order (cumulative first, then sparkline shared-scale, then compare).
+- **Copy-as-CSV registry**: every virtual column registers itself with the
+  copy module's "include GS virtual columns" enumeration (`009-copy-as-csv`).
+  Deactivating a virtual column MUST deregister it.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+The combined requirements set is the union of `005-sparkline` FR-001..FR-028,
+`008-cumulative-column` FR-001..FR-020, and `010-diff-compare` FR-011/FR-012
+(column-mode appended column only), *with the following additions and
+reconciliations*:
+
+**Virtual-column scaffold (new, replaces the equivalent fragments in each
+source spec)**
+
+- **FR-VC-001**: Grid-Sight MUST expose, internally, a single virtual-column
+  scaffold (`enrichments/virtual-column.ts`) responsible for:
+  - appending one `<th>` to every header row in `<thead>`,
+  - appending one `<td>` to every body row in `<tbody>`,
+  - appending one empty `<td>` to every `<tfoot>` row,
+  - assigning a stable internal id to each appended column,
+  - removing every appended cell cleanly on detach.
+- **FR-VC-002**: Each feature MUST register a renderer with the scaffold via
+  a typed registration call (`registerVirtualColumn({ kind, ... })`) and MUST
+  NOT touch `<th>` / `<td>` cells directly outside its renderer's per-cell
+  output node.
+- **FR-VC-003**: The scaffold MUST own column ordering across features. The
+  canonical left-to-right order is:
+  1. Every cumulative column in activation order;
+  2. The column-compare column (at most one);
+  3. The sparkline column (at most one — always last).
+- **FR-VC-004**: When the visible-row pipeline emits a change event, the
+  scaffold MUST notify every registered renderer in dependency order
+  (cumulative → compare → sparkline-shared-scale) within one animation frame.
+- **FR-VC-005**: The scaffold MUST register every active virtual column with
+  the copy-as-CSV registry (`009-copy-as-csv`) and deregister on detach.
+- **FR-VC-006**: Detaching the scaffold MUST leave the host table's DOM
+  byte-identical to the pre-activation snapshot, except for any GS-injected
+  lozenge nodes outside the scaffold's scope.
+- **FR-VC-007**: The scaffold MUST enforce the qualifier rules of each
+  feature it hosts (numeric column for cumulative, ≥ 3 numeric body columns
+  for sparkline, no `rowspan` / `colspan` on source body cells) before
+  rendering. Renderers MUST refuse activation on disqualified tables.
+
+**Per-feature renderers**
+
+- Cumulative-column renderer: implements `008-cumulative-column` FR-004,
+  FR-005 (computation), FR-008 (header text), FR-011 (recompute triggers,
+  via FR-VC-004), FR-012 (skip non-numeric), FR-016/FR-017 (a11y).
+- Sparkline renderer: implements `005-sparkline` FR-005 (inline SVG, no
+  external refs), FR-008..FR-011 (bar style, scaling modes), FR-012..FR-014
+  (hover/focus, tooltip, header highlight), FR-015/FR-016 (mode toggle),
+  FR-020..FR-023 (a11y).
+- Compare-column renderer: implements `010-diff-compare` FR-008..FR-010
+  (delta computation), FR-012 (header text "Δ <colB> − <colA>"), FR-013
+  (delta display modes), FR-014 (direction by colour + glyph), FR-022 (per-
+  cell `aria-label`).
+
+**Lozenges and affordances (carried)**
+
+- Cumulative Σ lozenge in the existing column-header cluster
+  (`008` FR-001/FR-002, FR-018).
+- Sparkline ⌇ lozenge in the table's corner cluster
+  (`005` FR-001, alongside the sliders S lozenge).
+- Compare Δ lozenge in the table's corner cluster
+  (`010` FR-001, FR-025). Note: the compare lozenge governs *both* row-mode
+  (out of scope here — see `010-diff-compare/spec.md`) and column-mode (in
+  scope here).
+
+**Persistence**
+
+- **FR-VC-008**: All virtual-column directives MUST be encoded under a
+  single per-page URL-fragment namespace (one block per table) with one entry
+  per active appended column.
+- **FR-VC-009**: Restoration MUST be applied before the user sees content
+  settle (one animation frame after first paint). Directives referring to
+  missing tables, missing source columns, or missing rows MUST be silently
+  dropped; surviving directives MUST still apply.
+- **FR-VC-010**: A URL directive describing an activation order that
+  contradicts FR-VC-003 MUST be silently re-canonicalised on restore. No
+  error is emitted.
+
+**Integration**
+
+- **FR-VC-011**: The scaffold consumes the Visible Row Sequence from
+  `utils/visible-rows.ts` exclusively. It MUST NOT read raw `tbody` order
+  except to capture the original-order snapshot at first activation.
+- **FR-VC-012**: Toggling Grid-Sight off MUST detach the scaffold (FR-VC-006)
+  while leaving the URL state intact, so toggling back on restores every
+  active virtual column.
+- **FR-VC-013**: `data-gs-ignore` on a table suppresses the scaffold
+  entirely. `data-gs-no-sparkline` / `data-gs-no-cumulative` /
+  `data-gs-no-compare` each suppress only their feature's lozenge without
+  affecting other appended columns on the same table.
+
+### Key Entities
+
+- **Virtual Column Directive**: `(table, kind, id, ...kind-specific-fields)`
+  where `kind ∈ {cumulative, compare, sparkline}`. Multiple cumulative
+  directives may coexist per table; at most one compare directive (column-
+  mode); at most one sparkline directive.
+- **Appended Column Record**: the injected `<th>` / `<td>` nodes for a single
+  virtual column, tagged with the directive's id.
+- **Virtual Column Registry**: the per-table set of active directives, in
+  canonical left-to-right order. Consumed by the copy-as-CSV registry.
+- **Persisted Virtual Column State**: the single per-page URL-fragment
+  serialisation containing every active directive across every table.
+- Per-feature entities (carried unchanged): Sparkline Eligible Column Set /
+  Row Series / Scaling Window (`005`); Cumulative Visible Row Sequence
+  (`008`; superseded here by the shared Visible Row Sequence from
+  `002-003-row-visibility`); Comparison Overlay / Pause State (`010`).
+
+## Success Criteria *(mandatory)*
+
+The combined feature inherits every measurable outcome from the three source
+specs. Where source specs quoted equivalent numbers, the combined number is
+the *max* of them (i.e. the budget covers the combined re-render).
+
+- **SC-001**: A user can activate any one virtual column (cumulative,
+  sparkline, or compare-column) in **one click** (cumulative, sparkline) or
+  **three clicks** (compare: Δ, col A, col B) from a Grid-Sight-enabled
+  page.
+- **SC-002**: For tables up to 1 000 rows × up to 10 numeric body columns,
+  activating any virtual column, switching its mode, or recomputing it on a
+  visible-row pipeline event MUST complete in **under 200 ms** (sparkline
+  initial render) or **under 100 ms** (cumulative / compare / sparkline
+  mode-flip) on a mid-range laptop.
+- **SC-003**: A URL containing virtual-column directives MUST restore them
+  with no visible flash beyond **one animation frame** after first paint.
+- **SC-004**: A shared URL MUST reproduce on another machine **100% of the
+  time** with no `localStorage` dependency.
+- **SC-005**: Toggling Grid-Sight off MUST detach every appended column with
+  **byte-identical DOM** to the pre-enrichment state (excluding GS-injected
+  lozenge nodes anywhere on the page).
+- **SC-006**: Every appended cell MUST have a non-empty accessible name
+  (`005` SC-006 generalised) — an automated audit on fixture tables finds
+  zero empty `aria-label`s on appended cells across all three feature
+  variants.
+- **SC-007 (new)**: With all three virtual-column variants active on one
+  table, the appended-column order MUST be canonical (FR-VC-003) on first
+  render and after every visible-row pipeline event, verified by an
+  automated parity check.
+
+## Assumptions
+
+Union of source specs, with the following additions and reconciliations:
+
+- **Append-only DOM**, no mutation of source cells (`005` Assumptions,
+  carried scaffold-wide).
+- **Numeric-column detection is shared** across all three features
+  (`005`, `008` Assumptions) — the same detector used by heatmap and
+  statistics.
+- **Visible-row pipeline is the only source of order and dim-state** for
+  virtual-column renderers (FR-VC-011). Renderers MUST NOT read raw
+  `tbody.rows` to make per-cell decisions.
+- **Single sparkline column, single compare column, multiple cumulative
+  columns** per table. v1 does not support multiple sparkline or compare
+  columns; the URL parser ignores extras silently.
+- **v1 sparkline style is bar only** (`005` Assumptions); the style
+  identifier exists in the persisted state for forward compatibility.
+- **v1 cumulative modes are sum and percent-of-total only** (`008`
+  Assumptions); running mean and percent-of-max are out of scope for v1.
+- **Column-compare is pairwise** (`010` Assumptions); N-way is out of scope.
+- **No new runtime dependency** (`005`, `008`, `010` all assert this; the
+  scaffold inherits the same constraint).
+- **Constitution bundle budget** (`.specify/memory/constitution.md`, ≤ 10 KB
+  gzipped) is respected by the combined feature. Sharing the scaffold *is*
+  the headline efficiency win against that ceiling.
+- **Row-compare overlay stays in `010-diff-compare/spec.md`**: this combined
+  spec covers only the column-mode appended column from `010`.
+
+## Implementation Streaming
+
+Each user story is shippable independently against the shared scaffold:
+
+1. **Scaffold first** (FR-VC-001..FR-VC-013) lands as a no-op pass through
+   that registers no renderers but freezes the registration API and the
+   ordering policy.
+2. **US1 (cumulative running sum)** and **US2 (sparkline)** can then be
+   implemented in parallel by different workers, each plugging into the
+   scaffold.
+3. **US4 (sparkline tooltip / header highlight)** and **US5 (scaling mode
+   toggle)** layer onto US2 without further scaffold work.
+4. **US3 (compare-column)** layers onto the row-compare interaction from
+   `010-diff-compare`, but is shippable independently as soon as the
+   scaffold can host it.
+5. **US6 (ordering)** is a property of the scaffold, demonstrated by an
+   integration test once any two of the three renderers are present.
+6. **US7 (URL persistence)** lands as a single PR covering the combined
+   directive shape; before then, each renderer may persist into a
+   per-feature subkey for development convenience.
+7. **US8 (visible-row pipeline cooperation)** requires the pipeline from
+   `002-003-row-visibility` and the scaffold change-event plumbing; it lands
+   when both are available.


### PR DESCRIPTION
## Summary

This PR introduces two new combined feature specifications that consolidate related functionality into unified designs:

1. **Row Visibility & Order** (`002-003-row-visibility/spec.md`): Combines sort and filter features into a single visible-row pipeline that downstream features consume
2. **Virtual Columns** (`005-008-010-virtual-columns/spec.md`): Combines sparkline, cumulative-column, and column-compare features into a shared scaffold for appending derived columns

## Key Changes

### Row Visibility & Order Specification
- Defines a unified `Visible Row Sequence` API (`utils/visible-rows.ts`) that both sort and filter feed into
- Establishes composition semantics: filter-then-sort pipeline where sort operates only on un-dimmed rows
- Specifies that dimmed rows remain in original document position and are never reordered by sort
- Consolidates URL persistence under a single per-table namespace with optional `sort` and `filters` fields
- Adds new User Story 5 (sort over filtered view) and clarifies edge cases for the combined interaction
- Defines change-event emission so downstream enrichments can re-render within one animation frame

### Virtual Columns Specification
- Introduces a shared scaffold (`enrichments/virtual-column.ts`) responsible for appending `<th>` / `<td>` cells across all three features
- Establishes canonical left-to-right column ordering: cumulative columns (in activation order) → compare column → sparkline column
- Specifies that each feature registers a renderer with the scaffold rather than manipulating DOM directly
- Defines dependency-ordered re-render on visible-row pipeline changes (cumulative → compare → sparkline)
- Consolidates URL persistence under a single per-page namespace with one entry per active appended column
- Adds new User Story 6 (multiple virtual columns coexist in defined order) and User Story 8 (cooperation with visible-row pipeline)
- Clarifies that renderers must consume the Visible Row Sequence exclusively, not raw DOM order

## Notable Implementation Details

- Both specs are designed as **combined designs with independent shipping priorities**: features remain separately valuable but are architected against one data model
- The virtual-column scaffold enforces qualifier rules before rendering (numeric column for cumulative, ≥3 numeric columns for sparkline, no rowspan/colspan)
- URL restoration must complete before content settles (one animation frame after first paint) with silent dropping of directives referring to missing tables/columns
- Toggling Grid-Sight off must leave DOM byte-identical to pre-activation state (excluding GS-injected lozenge nodes)
- Both specs inherit measurable success criteria from source specs, using the max budget where equivalent numbers were quoted

These specifications establish the architectural foundation for how sort/filter and virtual columns interact, enabling downstream features to read a consistent visible-row projection and ensuring proper composition of multiple appended columns.

https://claude.ai/code/session_013TvvrXLZ5KtAazSjtat7BA