### PR TITLE
docs(specs): add 012-capability-filtering specification

### DIFF
--- a/.claude/skills/speckit-review/SKILL.md
+++ b/.claude/skills/speckit-review/SKILL.md
@@ -39,16 +39,16 @@ If running low on context or the user asks to compress: Step 0 > Test coverage d
 
 ## Engineering Preferences (guide your recommendations)
 
-* **Constitution is law** — the principles in `.specify/memory/constitution.md` override all other considerations. Flag violations as CRITICAL.
-* **Bundle budget is a hard ceiling** — Principle I caps the IIFE at 10 KB gzipped. Any growth must justify its bytes; a feature targeting ≤ 1 KB should not slip to 5 KB unchallenged.
-* **DRY is important** — flag repetition aggressively across both the plan and existing code it touches.
-* **Well-tested code is non-negotiable** — Principle II mandates Vitest unit tests and Playwright e2e tests green at merge; new behaviour without tests is a blocker.
-* **Engineered enough** — not under-engineered (fragile, hacky) and not over-engineered (premature abstraction, unnecessary complexity). The Development-Phase Posture lets us move fast, but not recklessly — backwards-compat is waived, bundle and a11y are not.
-* **Bias toward explicit over clever** — TypeScript is configured strictly; flag any `any`, `as unknown as`, or non-null `!` that hides a real type problem.
-* **Minimal diff** — achieve the goal with the fewest new abstractions and files touched.
-* **Offline-first always** — every design decision must work without network and from `file://` (Principle VI). Any fetch, font CDN, or analytics call is a CRITICAL violation.
-* **Accessibility by default** — every UI affordance must be keyboard-operable and convey state to AT; colour MUST NOT be the sole channel (Principle III).
-* **Progressive enhancement** — the library MUST work as a `<script>` drop-in with no build step AND as ESM (Principle IV). A design that only works for one consumer mode is a violation.
+- **Constitution is law** — the principles in `.specify/memory/constitution.md` override all other considerations. Flag violations as CRITICAL.
+- **Bundle budget is a hard ceiling** — Principle I caps the IIFE at 10 KB gzipped. Any growth must justify its bytes; a feature targeting ≤ 1 KB should not slip to 5 KB unchallenged.
+- **DRY is important** — flag repetition aggressively across both the plan and existing code it touches.
+- **Well-tested code is non-negotiable** — Principle II mandates Vitest unit tests and Playwright e2e tests green at merge; new behaviour without tests is a blocker.
+- **Engineered enough** — not under-engineered (fragile, hacky) and not over-engineered (premature abstraction, unnecessary complexity). The Development-Phase Posture lets us move fast, but not recklessly — backwards-compat is waived, bundle and a11y are not.
+- **Bias toward explicit over clever** — TypeScript is configured strictly; flag any `any`, `as unknown as`, or non-null `!` that hides a real type problem.
+- **Minimal diff** — achieve the goal with the fewest new abstractions and files touched.
+- **Offline-first always** — every design decision must work without network and from `file://` (Principle VI). Any fetch, font CDN, or analytics call is a CRITICAL violation.
+- **Accessibility by default** — every UI affordance must be keyboard-operable and convey state to AT; colour MUST NOT be the sole channel (Principle III).
+- **Progressive enhancement** — the library MUST work as a `<script>` drop-in with no build step AND as ESM (Principle IV). A design that only works for one consumer mode is a violation.
 
 ## Execution Steps
 
@@ -94,10 +94,12 @@ Read all available design artifacts:
 3. **Check the bundle baseline**: If `dist/grid-sight.iife.js` exists, note its current gzipped size so you can sanity-check the plan's projected delta against the 10 KB ceiling.
 
 4. **Check git history** for the feature branch:
-   ```
+
+   ```bash
    git log --oneline -20
    git log --oneline main..HEAD  # if not on main
    ```
+
    If prior commits suggest a previous review cycle (review-driven refactors, reverted changes), note what changed and be more aggressive reviewing those areas.
 
 5. **Record findings** for use in Step 0 and the "What Already Exists" output.
@@ -132,7 +134,7 @@ Then use AskUserQuestion to present your findings and ask the user to choose one
 
 Evaluate the plan against the codebase and constitution:
 
-* **Constitution alignment**: Check every architectural decision against the relevant principle. Pay special attention to:
+- **Constitution alignment**: Check every architectural decision against the relevant principle. Pay special attention to:
   - **Principle I (Lightweight & Minimal Dependencies)**: Any new runtime dependency? Does the projected bundle delta keep the IIFE under 10 KB gzipped?
   - **Principle II (Test Discipline)**: Are Vitest unit, Storybook interaction, and Playwright e2e tests planned for every new code path?
   - **Principle III (Accessibility by Default)**: Are all new UI affordances keyboard-operable? Do they expose state to AT? Is colour ever the sole channel for information?
@@ -141,18 +143,18 @@ Evaluate the plan against the codebase and constitution:
   - **Principle VI (Offline-First / Air-Gapped)**: Any fetch, font CDN, analytics, or telemetry call? Anything that would break from `file://`?
   - **Development-Phase Posture**: Backwards-compat is waived pre-production — flag any energy spent on compat shims that the posture explicitly excuses.
 
-* **Component boundaries and coupling**: Review the dependency graph between proposed and existing modules. Grid-Sight's layout is `core/` (detection, processors) → `enrichments/` (registration / orchestration) → `ui/` (DOM + a11y) → `utils/` (pure logic). Flag layering violations (e.g. `utils/` importing from `ui/`) or circular dependencies.
+- **Component boundaries and coupling**: Review the dependency graph between proposed and existing modules. Grid-Sight's layout is `core/` (detection, processors) → `enrichments/` (registration / orchestration) → `ui/` (DOM + a11y) → `utils/` (pure logic). Flag layering violations (e.g. `utils/` importing from `ui/`) or circular dependencies.
 
-* **Data flow patterns**: Trace data from input (host page DOM, page config, URL fragment, localStorage) to runtime state to output (lozenges, popups, persistence writes). Identify potential bottlenecks and races (e.g. config read after init).
+- **Data flow patterns**: Trace data from input (host page DOM, page config, URL fragment, localStorage) to runtime state to output (lozenges, popups, persistence writes). Identify potential bottlenecks and races (e.g. config read after init).
 
-* **Integration with existing code**: For each touchpoint with existing code (found in Step 3), assess whether the integration approach is clean or introduces coupling. Watch for:
+- **Integration with existing code**: For each touchpoint with existing code (found in Step 3), assess whether the integration approach is clean or introduces coupling. Watch for:
   - New code reaching into `src/ui/header-utils.ts` lozenge-spec assembly in more than one place.
   - Duplication of the slider persistence model rather than reuse.
   - Bypassing `data-gs-ignore` honouring.
 
-* **Failure scenarios**: For each new codepath or integration point, describe one realistic production failure scenario (malformed config object, corrupted localStorage value, missing DOM container, host CSS clobbering a panel) and whether the plan accounts for it.
+- **Failure scenarios**: For each new codepath or integration point, describe one realistic production failure scenario (malformed config object, corrupted localStorage value, missing DOM container, host CSS clobbering a panel) and whether the plan accounts for it.
 
-* **Diagrams**: Note whether key flows deserve ASCII diagrams in the plan or in code comments.
+- **Diagrams**: Note whether key flows deserve ASCII diagrams in the plan or in code comments.
 
 **STOP.** You MUST call AskUserQuestion NOW with your findings from this section. Do NOT proceed to the next section until the user responds.
 
@@ -160,25 +162,25 @@ Evaluate the plan against the codebase and constitution:
 
 Evaluate the proposed design in data-model.md, contracts/, and plan.md:
 
-* **DRY violations**: Check proposed types and interfaces against existing ones. Flag duplication aggressively — especially:
+- **DRY violations**: Check proposed types and interfaces against existing ones. Flag duplication aggressively — especially:
   - Re-declarations of existing types (e.g. another `EnrichmentType` enum next to the one in `src/ui/enrichment-menu.ts`).
   - Parallel implementations of persistence that the slider already solved.
   - Repeated id-normalisation logic that should be one helper.
 
-* **Naming consistency with existing code**: Grid-Sight already has in-code identifiers for shipped enrichments (`heatmap`, `sliders`, `slider`, `threshold-slider`, `frequency`, `frequency-chart`, …). Flag any spec/plan that introduces a parallel vocabulary (e.g. spec says `slider` while code says `sliders`) without reconciling explicitly in research.
+- **Naming consistency with existing code**: Grid-Sight already has in-code identifiers for shipped enrichments (`heatmap`, `sliders`, `slider`, `threshold-slider`, `frequency`, `frequency-chart`, …). Flag any spec/plan that introduces a parallel vocabulary (e.g. spec says `slider` while code says `sliders`) without reconciling explicitly in research.
 
-* **Error handling patterns**: Are failure modes explicit? Does the design fall back rather than throw at init? Are the console warnings used to surface misuse (rather than silent fall-through) where appropriate?
+- **Error handling patterns**: Are failure modes explicit? Does the design fall back rather than throw at init? Are the console warnings used to surface misuse (rather than silent fall-through) where appropriate?
 
-* **Over/under-engineering**: Is the design proportional to the problem? Flag premature abstractions (unnecessary base classes, overly generic interfaces, "future-proofing" beyond what specs 002–010 actually need) and missing structure (god objects, mixed concerns, DOM logic in `core/`).
+- **Over/under-engineering**: Is the design proportional to the problem? Flag premature abstractions (unnecessary base classes, overly generic interfaces, "future-proofing" beyond what specs 002–010 actually need) and missing structure (god objects, mixed concerns, DOM logic in `core/`).
 
-* **Type safety**: TypeScript is configured strictly (zero errors required by Principle II / Workflow gates). Flag:
+- **Type safety**: TypeScript is configured strictly (zero errors required by Principle II / Workflow gates). Flag:
   - Any `any` in proposed type signatures.
   - `as unknown as T` casts that paper over a real shape mismatch.
   - Optional fields that should be required (or vice-versa) given the data flow.
 
-* **Existing code impact**: For files the plan modifies (found in Step 3), review whether the proposed changes conflict with existing patterns, break existing tests, or introduce inconsistencies. Pay attention to the lozenge cluster code in `src/ui/header-utils.ts` — modifications there ripple to every demo.
+- **Existing code impact**: For files the plan modifies (found in Step 3), review whether the proposed changes conflict with existing patterns, break existing tests, or introduce inconsistencies. Pay attention to the lozenge cluster code in `src/ui/header-utils.ts` — modifications there ripple to every demo.
 
-* **Stale documentation**: If the plan modifies code that has inline comments, README references, or `CLAUDE.md` content, note that these will need updating. Likewise quickstart.md if the contract changes.
+- **Stale documentation**: If the plan modifies code that has inline comments, README references, or `CLAUDE.md` content, note that these will need updating. Likewise quickstart.md if the contract changes.
 
 **STOP.** You MUST call AskUserQuestion NOW with your findings from this section. Do NOT proceed to the next section until the user responds.
 
@@ -207,12 +209,12 @@ Flag any new codepath that has no planned test coverage.
 
 Evaluate with Grid-Sight's domain constraints in mind:
 
-* **Bundle size**: Does the plan's projected gzipped delta hold up under scrutiny? Are the heaviest contributors (UI panels, large data literals, inlined SVG) accounted for? Is there a credible mitigation plan if the delta blows the budget?
-* **Runtime budget**: Constitution caps processing of a 1,000-cell table at 100 ms on a mid-range laptop, and forbids main-thread blocking beyond one animation frame. Does the design hit those numbers under realistic data (large heatmaps, many tables on one page, many lozenges)?
-* **Interaction latency**: Slider drag, lozenge toggle, panel checkbox flip — each must complete within one animation frame (≤ 16 ms). Flag any design that walks the entire DOM on each interaction.
-* **Memory & DOM growth**: Are large collections held in memory unnecessarily? Are detached DOM nodes (closed popups, removed lozenges) reachable through retained references? Are event listeners cleaned up on tearDown?
-* **localStorage / URL footprint**: URL fragments are visible everywhere they're shared. Are they kept short? Is the localStorage payload bounded (no unbounded history)?
-* **Startup impact**: Time from `<script>` parse to first lozenge rendered. Does the feature add measurable cost on a page with no qualifying tables? It should not.
+- **Bundle size**: Does the plan's projected gzipped delta hold up under scrutiny? Are the heaviest contributors (UI panels, large data literals, inlined SVG) accounted for? Is there a credible mitigation plan if the delta blows the budget?
+- **Runtime budget**: Constitution caps processing of a 1,000-cell table at 100 ms on a mid-range laptop, and forbids main-thread blocking beyond one animation frame. Does the design hit those numbers under realistic data (large heatmaps, many tables on one page, many lozenges)?
+- **Interaction latency**: Slider drag, lozenge toggle, panel checkbox flip — each must complete within one animation frame (≤ 16 ms). Flag any design that walks the entire DOM on each interaction.
+- **Memory & DOM growth**: Are large collections held in memory unnecessarily? Are detached DOM nodes (closed popups, removed lozenges) reachable through retained references? Are event listeners cleaned up on tearDown?
+- **localStorage / URL footprint**: URL fragments are visible everywhere they're shared. Are they kept short? Is the localStorage payload bounded (no unbounded history)?
+- **Startup impact**: Time from `<script>` parse to first lozenge rendered. Does the feature add measurable cost on a page with no qualifying tables? It should not.
 
 **STOP.** You MUST call AskUserQuestion NOW with your findings from this section. Do NOT proceed to the next section until the user responds.
 
@@ -247,10 +249,10 @@ List existing code, modules, and flows (found in Step 3) that already partially 
 
 Any deferred work that is genuinely valuable MUST be written up as potential backlog entries (in BACKLOG.md if it exists, otherwise propose creating one). Each entry needs:
 
-* **What**: One-line description of the work
-* **Why**: The concrete problem it solves or value it unlocks
-* **Context**: Enough detail that someone picking this up in 3 months understands the motivation
-* **Depends on / blocked by**: Any prerequisites
+- **What**: One-line description of the work
+- **Why**: The concrete problem it solves or value it unlocks
+- **Context**: Enough detail that someone picking this up in 3 months understands the motivation
+- **Depends on / blocked by**: Any prerequisites
 
 Do NOT write vague bullet points. Ask the user which deferred items they want captured before proposing backlog entries.
 
@@ -298,11 +300,11 @@ These may cause problems during implementation if not addressed.
 
 ## Formatting Rules
 
-* NUMBER issues (1, 2, 3...) and give LETTERS for options (A, B, C...).
-* When using AskUserQuestion, label each option with issue NUMBER and option LETTER.
-* Recommended option is always listed first.
-* Keep each option to one sentence max.
-* After each review section, pause and ask for feedback before moving on.
+- NUMBER issues (1, 2, 3...) and give LETTERS for options (A, B, C...).
+- When using AskUserQuestion, label each option with issue NUMBER and option LETTER.
+- Recommended option is always listed first.
+- Keep each option to one sentence max.
+- After each review section, pause and ask for feedback before moving on.
 
 ## Unresolved Decisions
 

--- a/.claude/skills/speckit-review/SKILL.md
+++ b/.claude/skills/speckit-review/SKILL.md
@@ -1,0 +1,313 @@
+---
+name: "speckit-review"
+description: "Review a plan thoroughly before task generation. Challenges scope, reviews architecture/design/tests/performance against existing code and the Grid-Sight constitution, with opinionated recommendations."
+argument-hint: "Optional reviewer guidance (e.g. \"focus on bundle budget\")"
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "adapted from debrief-future/.claude/commands/speckit.review.md"
+  source: "https://raw.githubusercontent.com/debrief/debrief-future/refs/heads/main/.claude/commands/speckit.review.md"
+user-invocable: true
+disable-model-invocation: false
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Purpose
+
+Review the implementation plan before committing to task generation. This is a strategic review gate that challenges scope, examines architectural decisions against existing code and the constitution, and surfaces issues while they're still cheap to fix.
+
+**This command is read-only.** It does not modify any files. It produces a structured review with opinionated recommendations and asks the user for decisions at each stage.
+
+After the review, suggested next steps:
+
+- **Create Tasks** — run `/speckit-tasks` to break the (possibly revised) plan into tasks
+- **Revise Plan** — run `/speckit-plan` to revise the plan based on review findings
+
+## Allowed Tools
+
+This review uses only: Read, Grep, Glob, Bash (read-only commands like `git log`, `git diff`, `find`), AskUserQuestion.
+
+## Priority Hierarchy
+
+If running low on context or the user asks to compress: Step 0 > Test coverage diagram > Opinionated recommendations > Everything else. Never skip Step 0 or the test coverage diagram.
+
+## Engineering Preferences (guide your recommendations)
+
+* **Constitution is law** — the principles in `.specify/memory/constitution.md` override all other considerations. Flag violations as CRITICAL.
+* **Bundle budget is a hard ceiling** — Principle I caps the IIFE at 10 KB gzipped. Any growth must justify its bytes; a feature targeting ≤ 1 KB should not slip to 5 KB unchallenged.
+* **DRY is important** — flag repetition aggressively across both the plan and existing code it touches.
+* **Well-tested code is non-negotiable** — Principle II mandates Vitest unit tests and Playwright e2e tests green at merge; new behaviour without tests is a blocker.
+* **Engineered enough** — not under-engineered (fragile, hacky) and not over-engineered (premature abstraction, unnecessary complexity). The Development-Phase Posture lets us move fast, but not recklessly — backwards-compat is waived, bundle and a11y are not.
+* **Bias toward explicit over clever** — TypeScript is configured strictly; flag any `any`, `as unknown as`, or non-null `!` that hides a real type problem.
+* **Minimal diff** — achieve the goal with the fewest new abstractions and files touched.
+* **Offline-first always** — every design decision must work without network and from `file://` (Principle VI). Any fetch, font CDN, or analytics call is a CRITICAL violation.
+* **Accessibility by default** — every UI affordance must be keyboard-operable and convey state to AT; colour MUST NOT be the sole channel (Principle III).
+* **Progressive enhancement** — the library MUST work as a `<script>` drop-in with no build step AND as ESM (Principle IV). A design that only works for one consumer mode is a violation.
+
+## Execution Steps
+
+### 1. Initialize Review Context
+
+Run `.specify/scripts/bash/check-prerequisites.sh --json` from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS.
+For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+Derive absolute paths:
+
+- SPEC = FEATURE_DIR/spec.md
+- PLAN = FEATURE_DIR/plan.md
+- RESEARCH = FEATURE_DIR/research.md (if available)
+- DATA_MODEL = FEATURE_DIR/data-model.md (if available)
+- CONTRACTS = FEATURE_DIR/contracts/ (if available)
+
+Abort with an error message if plan.md is missing (instruct user to run `/speckit-plan` first).
+
+### 2. Load Artifacts
+
+Read all available design artifacts:
+
+1. **spec.md** — user stories, requirements, success criteria
+2. **plan.md** — technical context, architecture, project structure, constitution check
+3. **research.md** — design decisions and alternatives (if exists)
+4. **data-model.md** — entities, relationships, validation rules (if exists)
+5. **contracts/** — public API definitions, DOM contract, URL/localStorage contract (if exists)
+6. **quickstart.md** — author-facing onboarding (if exists; cross-check accuracy against contracts)
+7. **`.specify/memory/constitution.md`** — Grid-Sight constitution (Principles I–VI + Development-Phase Posture)
+
+### 3. Survey Existing Code
+
+**This step is critical.** The plan does not exist in a vacuum — it integrates with or modifies existing code.
+
+1. **Identify files the plan touches**: Read plan.md's Project Structure section and extract all source file paths, directories, and modules mentioned.
+
+2. **Search for existing implementations**: For each entity, module, or DOM contract proposed in the plan:
+   - Glob for files with matching names in the repository
+   - Grep for key type names, function names, class names, and `data-gs-*` attributes
+   - Note what already exists vs what the plan proposes to create
+   - Pay particular attention to the existing `src/core/`, `src/enrichments/`, `src/ui/`, `src/utils/` boundaries — does the plan honour them?
+
+3. **Check the bundle baseline**: If `dist/grid-sight.iife.js` exists, note its current gzipped size so you can sanity-check the plan's projected delta against the 10 KB ceiling.
+
+4. **Check git history** for the feature branch:
+   ```
+   git log --oneline -20
+   git log --oneline main..HEAD  # if not on main
+   ```
+   If prior commits suggest a previous review cycle (review-driven refactors, reverted changes), note what changed and be more aggressive reviewing those areas.
+
+5. **Record findings** for use in Step 0 and the "What Already Exists" output.
+
+### 4. Step 0 — Scope Challenge
+
+**BEFORE reviewing anything else**, answer these questions:
+
+1. **What existing code already partially or fully solves each sub-problem?** Reference specific files and functions found in Step 3. Can the plan reuse existing patterns (e.g. the slider's URL+localStorage persistence model, the lozenge cluster in `header-utils.ts`, the `data-gs-*` attribute convention) rather than building parallel ones?
+
+2. **What is the minimum set of changes that achieves the stated goal?** Flag any work in the plan that could be deferred without blocking the core objective. Be ruthless about scope creep — particularly UI scaffolding, new public API symbols, and demo content that isn't on the critical path.
+
+3. **Complexity check**: Count the files the plan creates or modifies, and the new types/modules it introduces. If the plan touches more than 8 files or introduces more than 2 new top-level concepts (modules, registries, public API symbols), treat that as a smell and challenge whether the same goal can be achieved with fewer moving parts.
+
+4. **Bundle budget pre-check**: Does the plan project a bundle delta? Is it credible? A feature claiming "≤ 1 KB" while introducing a new UI panel, a new persistence path, and a new public API surface deserves scrutiny.
+
+5. **Constitution compliance pre-check**: Does the plan's Constitution Check section in plan.md correctly identify all six principles plus Development-Phase Posture? Are there violations it missed (e.g. a hidden `fetch()`, a non-keyboard-operable widget, a feature that breaks the IIFE path)?
+
+Then use AskUserQuestion to present your findings and ask the user to choose one of three review modes:
+
+**Option A — SCOPE REDUCTION**: The plan is overbuilt. You will propose a minimal version that achieves the core goal, then review that reduced plan.
+
+**Option B — FULL REVIEW**: Work through interactively, one section at a time (Architecture → Design Quality → Tests → Performance) with at most 4 top issues per section.
+
+**Option C — COMPRESSED REVIEW**: Step 0 + one combined pass covering all 4 sections. For each section, pick the single most important issue. Present as a single numbered list + mandatory test coverage diagram + completion summary. One AskUserQuestion round at the end.
+
+**Critical: If the user does NOT select SCOPE REDUCTION, respect that decision fully.** Your job becomes making the plan they chose succeed, not continuing to lobby for a smaller plan. Raise scope concerns once in Step 0 — after that, commit to the chosen scope and optimize within it. Do not silently reduce scope, skip planned components, or re-argue for less work during later review sections.
+
+### 5. Review Sections (after scope is agreed)
+
+#### 5A. Architecture Review
+
+Evaluate the plan against the codebase and constitution:
+
+* **Constitution alignment**: Check every architectural decision against the relevant principle. Pay special attention to:
+  - **Principle I (Lightweight & Minimal Dependencies)**: Any new runtime dependency? Does the projected bundle delta keep the IIFE under 10 KB gzipped?
+  - **Principle II (Test Discipline)**: Are Vitest unit, Storybook interaction, and Playwright e2e tests planned for every new code path?
+  - **Principle III (Accessibility by Default)**: Are all new UI affordances keyboard-operable? Do they expose state to AT? Is colour ever the sole channel for information?
+  - **Principle IV (Progressive Enhancement)**: Does the design work as an IIFE drop-in AND as ESM? Does it degrade gracefully when optional inputs are missing?
+  - **Principle V (Cross-Browser Compatibility)**: Any newly-shipped browser API used without a feature-detect / fallback?
+  - **Principle VI (Offline-First / Air-Gapped)**: Any fetch, font CDN, analytics, or telemetry call? Anything that would break from `file://`?
+  - **Development-Phase Posture**: Backwards-compat is waived pre-production — flag any energy spent on compat shims that the posture explicitly excuses.
+
+* **Component boundaries and coupling**: Review the dependency graph between proposed and existing modules. Grid-Sight's layout is `core/` (detection, processors) → `enrichments/` (registration / orchestration) → `ui/` (DOM + a11y) → `utils/` (pure logic). Flag layering violations (e.g. `utils/` importing from `ui/`) or circular dependencies.
+
+* **Data flow patterns**: Trace data from input (host page DOM, page config, URL fragment, localStorage) to runtime state to output (lozenges, popups, persistence writes). Identify potential bottlenecks and races (e.g. config read after init).
+
+* **Integration with existing code**: For each touchpoint with existing code (found in Step 3), assess whether the integration approach is clean or introduces coupling. Watch for:
+  - New code reaching into `src/ui/header-utils.ts` lozenge-spec assembly in more than one place.
+  - Duplication of the slider persistence model rather than reuse.
+  - Bypassing `data-gs-ignore` honouring.
+
+* **Failure scenarios**: For each new codepath or integration point, describe one realistic production failure scenario (malformed config object, corrupted localStorage value, missing DOM container, host CSS clobbering a panel) and whether the plan accounts for it.
+
+* **Diagrams**: Note whether key flows deserve ASCII diagrams in the plan or in code comments.
+
+**STOP.** You MUST call AskUserQuestion NOW with your findings from this section. Do NOT proceed to the next section until the user responds.
+
+#### 5B. Design Quality Review
+
+Evaluate the proposed design in data-model.md, contracts/, and plan.md:
+
+* **DRY violations**: Check proposed types and interfaces against existing ones. Flag duplication aggressively — especially:
+  - Re-declarations of existing types (e.g. another `EnrichmentType` enum next to the one in `src/ui/enrichment-menu.ts`).
+  - Parallel implementations of persistence that the slider already solved.
+  - Repeated id-normalisation logic that should be one helper.
+
+* **Naming consistency with existing code**: Grid-Sight already has in-code identifiers for shipped enrichments (`heatmap`, `sliders`, `slider`, `threshold-slider`, `frequency`, `frequency-chart`, …). Flag any spec/plan that introduces a parallel vocabulary (e.g. spec says `slider` while code says `sliders`) without reconciling explicitly in research.
+
+* **Error handling patterns**: Are failure modes explicit? Does the design fall back rather than throw at init? Are the console warnings used to surface misuse (rather than silent fall-through) where appropriate?
+
+* **Over/under-engineering**: Is the design proportional to the problem? Flag premature abstractions (unnecessary base classes, overly generic interfaces, "future-proofing" beyond what specs 002–010 actually need) and missing structure (god objects, mixed concerns, DOM logic in `core/`).
+
+* **Type safety**: TypeScript is configured strictly (zero errors required by Principle II / Workflow gates). Flag:
+  - Any `any` in proposed type signatures.
+  - `as unknown as T` casts that paper over a real shape mismatch.
+  - Optional fields that should be required (or vice-versa) given the data flow.
+
+* **Existing code impact**: For files the plan modifies (found in Step 3), review whether the proposed changes conflict with existing patterns, break existing tests, or introduce inconsistencies. Pay attention to the lozenge cluster code in `src/ui/header-utils.ts` — modifications there ripple to every demo.
+
+* **Stale documentation**: If the plan modifies code that has inline comments, README references, or `CLAUDE.md` content, note that these will need updating. Likewise quickstart.md if the contract changes.
+
+**STOP.** You MUST call AskUserQuestion NOW with your findings from this section. Do NOT proceed to the next section until the user responds.
+
+#### 5C. Test Review
+
+Build a diagram (ASCII art) of all new:
+
+- User journeys (from spec.md user stories)
+- Data flows (from data-model.md and contracts/)
+- Codepaths and branching (from plan.md architecture)
+
+For each item in the diagram, verify:
+
+1. **Unit tests** (Vitest): Are proposed pure functions and parsers covered, including edge cases (empty input, malformed input, unknown ids, case variants, duplicates)?
+2. **Component tests** (Storybook interaction tests via `@storybook/addon-vitest`): Are new UI affordances exercised with realistic DOM (focus order, keyboard activation, AT-relevant attributes)?
+3. **End-to-end tests** (Playwright): Are full host-page flows covered — load → init → user action → persistence → reload? Are demo pages exercised so the demo-subset acceptance criteria are mechanically verified?
+4. **Acceptance criteria**: Can every acceptance scenario from spec.md be mapped to a testable assertion in one of the test layers above?
+5. **Existing test impact**: Will the proposed changes break any existing tests? Grep for test files that reference modified modules (e.g. `src/ui/__tests__/`, `src/enrichments/__tests__/`, `tests/e2e/`).
+6. **Bundle size assertion**: Is there a test or CI step that measures the IIFE size and fails the PR if it crosses 10 KB gzipped?
+
+Flag any new codepath that has no planned test coverage.
+
+**STOP.** You MUST call AskUserQuestion NOW with your findings from this section. Do NOT proceed to the next section until the user responds.
+
+#### 5D. Performance Review
+
+Evaluate with Grid-Sight's domain constraints in mind:
+
+* **Bundle size**: Does the plan's projected gzipped delta hold up under scrutiny? Are the heaviest contributors (UI panels, large data literals, inlined SVG) accounted for? Is there a credible mitigation plan if the delta blows the budget?
+* **Runtime budget**: Constitution caps processing of a 1,000-cell table at 100 ms on a mid-range laptop, and forbids main-thread blocking beyond one animation frame. Does the design hit those numbers under realistic data (large heatmaps, many tables on one page, many lozenges)?
+* **Interaction latency**: Slider drag, lozenge toggle, panel checkbox flip — each must complete within one animation frame (≤ 16 ms). Flag any design that walks the entire DOM on each interaction.
+* **Memory & DOM growth**: Are large collections held in memory unnecessarily? Are detached DOM nodes (closed popups, removed lozenges) reachable through retained references? Are event listeners cleaned up on tearDown?
+* **localStorage / URL footprint**: URL fragments are visible everywhere they're shared. Are they kept short? Is the localStorage payload bounded (no unbounded history)?
+* **Startup impact**: Time from `<script>` parse to first lozenge rendered. Does the feature add measurable cost on a page with no qualifying tables? It should not.
+
+**STOP.** You MUST call AskUserQuestion NOW with your findings from this section. Do NOT proceed to the next section until the user responds.
+
+## For Each Issue Found
+
+For every specific issue (bug, smell, design concern, or risk):
+
+1. **Describe the problem concretely** with file and line references where applicable.
+2. **Present 2–3 options**, including "do nothing" where reasonable.
+3. For each option, state in one line: effort, risk, and maintenance burden.
+4. **Lead with your recommendation.** State it as a directive: "Do B. Here's why:" — not "Option B might be worth considering." Be opinionated.
+5. **Map the reasoning to a specific engineering preference or constitution principle.** One sentence connecting your recommendation to a principle (e.g. "Principle I — keeps the bundle under the 10 KB ceiling").
+6. **AskUserQuestion format**: Start with "We recommend [LETTER]: [one-line reason]" then list all options. Label with issue NUMBER + option LETTER (e.g., "3A", "3B").
+
+## Required Outputs
+
+### "NOT in scope" Section
+
+Every review MUST produce a "NOT in scope" section listing work that was considered and explicitly deferred, with a one-line rationale for each item.
+
+### "What Already Exists" Section
+
+List existing code, modules, and flows (found in Step 3) that already partially solve sub-problems in this plan. State whether the plan reuses them or unnecessarily rebuilds them. Pay particular attention to:
+
+- Slider URL+localStorage persistence (`src/utils/slider-persistence.ts`)
+- Lozenge cluster assembly (`src/ui/header-utils.ts`)
+- Enrichment menu items list (`src/ui/enrichment-menu.ts`)
+- Table registry (`src/index.ts`)
+- `data-gs-*` attribute convention
+
+### Deferred Items for BACKLOG
+
+Any deferred work that is genuinely valuable MUST be written up as potential backlog entries (in BACKLOG.md if it exists, otherwise propose creating one). Each entry needs:
+
+* **What**: One-line description of the work
+* **Why**: The concrete problem it solves or value it unlocks
+* **Context**: Enough detail that someone picking this up in 3 months understands the motivation
+* **Depends on / blocked by**: Any prerequisites
+
+Do NOT write vague bullet points. Ask the user which deferred items they want captured before proposing backlog entries.
+
+### Diagrams
+
+The review should use ASCII diagrams for any non-trivial data flow, state machine, or processing pipeline being discussed. Additionally, identify which files in the implementation should get inline ASCII diagram comments — particularly:
+
+- Modules with complex state transitions (e.g. EffectiveEnabledSet precedence resolver)
+- Code with multi-step pipelines (e.g. page config → normalised config → effective set → lozenge filter)
+- Integration points with non-obvious data flow (e.g. URL fragment → persistence → toggle panel → tearDown)
+
+### Failure Modes
+
+For each new codepath identified in the test review diagram, list one realistic way it could fail in production (malformed config, corrupted localStorage, missing DOM container, race between init and pageConfig assignment, host CSS clobbering layout, etc.) and whether:
+
+1. A test would cover that failure
+2. Error handling exists for it
+3. The user (page author or end-visitor) would see a clear console warning or a silent failure
+
+If any failure mode has no test AND no error handling AND would be silent (the page just looks broken with no diagnostic), flag it as a **critical gap**.
+
+### Completion Summary
+
+At the end of the review, display this summary:
+
+```
+## Review Summary
+
+- Step 0: Scope Challenge (user chose: ___)
+- Architecture Review: ___ issues found
+- Design Quality Review: ___ issues found
+- Test Review: diagram produced, ___ gaps identified
+- Performance Review: ___ issues found
+- NOT in scope: written
+- What already exists: written
+- Deferred items: ___ items proposed to user
+- Failure modes: ___ critical gaps flagged
+- Constitution violations: ___ found
+
+### Unresolved Decisions
+
+[List any AskUserQuestion decisions the user did not respond to or skipped]
+These may cause problems during implementation if not addressed.
+```
+
+## Formatting Rules
+
+* NUMBER issues (1, 2, 3...) and give LETTERS for options (A, B, C...).
+* When using AskUserQuestion, label each option with issue NUMBER and option LETTER.
+* Recommended option is always listed first.
+* Keep each option to one sentence max.
+* After each review section, pause and ask for feedback before moving on.
+
+## Unresolved Decisions
+
+If the user does not respond to an AskUserQuestion or interrupts to move on, note which decisions were left unresolved. At the end of the review, list these as "Unresolved decisions that may bite you later" — never silently default to an option.
+
+## Context
+
+$ARGUMENTS

--- a/.claude/skills/speckit-review/SKILL.md
+++ b/.claude/skills/speckit-review/SKILL.md
@@ -10,6 +10,8 @@ user-invocable: true
 disable-model-invocation: false
 ---
 
+# Speckit Review
+
 ## User Input
 
 ```text
@@ -278,7 +280,7 @@ If any failure mode has no test AND no error handling AND would be silent (the p
 
 At the end of the review, display this summary:
 
-```
+```text
 ## Review Summary
 
 - Step 0: Scope Challenge (user chose: ___)

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/001-dynamic-sliders"
+  "feature_directory": "specs/012-capability-filtering"
 }

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,80 @@
+# Backlog
+
+Deferred work that is genuinely valuable but not part of a current feature
+branch. Each entry is captured here so the rationale survives the conversation
+that produced it. Newest entries on top.
+
+Format per entry: **What** (one line) · **Why** (the concrete problem it
+solves) · **Context** (enough that someone picking this up in three months
+understands the motivation) · **Depends on / blocked by** (any prerequisites).
+
+---
+
+## Investigate `zscore` and `aggregate` in `enrichment-menu.ts`
+
+- **What**: Decide whether `EnrichmentType` literals `'zscore'` and
+  `'aggregate'` in `src/ui/enrichment-menu.ts` are dead code (delete) or
+  planned future enrichments (write specs and add to the enrichment registry).
+- **Why**: The 012-capability-filtering review (R-1.1) renamed every other
+  `EnrichmentType` id to match the new registry vocabulary and treated these
+  two as dead code on the assumption that they have no handler, no demo, and
+  no spec. If either is actually planned, the call should be reversed before
+  someone re-discovers them and reintroduces the inconsistency.
+- **Context**: Grep for `'zscore'` and `'aggregate'` across the repo. If only
+  the menu-type literal and possibly an obsolete story reference them, delete
+  them outright (Development-Phase Posture waives backwards-compat). If they
+  reflect a planned statistical-marker enrichment, write a spec under
+  `specs/`, register the id in `src/core/enrichment-registry.ts`, and link
+  back here.
+- **Depends on / blocked by**: 012-capability-filtering must ship first so
+  the registry exists to register new ids against.
+
+## Per-table enrichment override
+
+- **What**: Allow a `data-gs-enrichments="heatmap,statistics"` attribute on
+  an individual `<table>` to override the page-level config for that one
+  table.
+- **Why**: 012-capability-filtering is scoped per-page. The minute two real
+  authoring teams need two different enrichment sets on the same page (e.g.
+  one categorical roster table next to one numeric lookup table on the same
+  page), they will reach for this. Today the workaround is `data-gs-ignore`
+  on one and a script-tag config on the other, which is heavy-handed.
+- **Context**: The natural extension point is a per-table
+  `EffectiveEnabledSet` derived from the page-level set ∩ the attribute's
+  list (or ∪ — UX call to make at spec time). The data-model.md "Out of
+  scope" section in 012-capability-filtering already names this as the
+  natural extension.
+- **Depends on / blocked by**: 012-capability-filtering.
+
+## Localised registry labels
+
+- **What**: Allow `EnrichmentRegistry.label` to be either a string (current)
+  or a `{ [lang: string]: string }` map; resolve via `document.documentElement.lang`
+  or `navigator.language`.
+- **Why**: The runtime toggle panel and any host-page enrichment chooser
+  that consumes `window.gridSight.enrichmentIds` currently show English
+  labels regardless of page language. For non-English demos and customer
+  deployments, this is visible polish missing.
+- **Context**: Only the panel and host-page consumers read `label`; the
+  identifier (`id`) stays language-neutral. Implementation is a one-function
+  change in the panel + a small type widening in the registry.
+- **Depends on / blocked by**: 012-capability-filtering. Customer demand for
+  a non-English deployment; not worth speculative effort otherwise.
+
+## Programmatic `setEnabled(id, bool)` API
+
+- **What**: Expose `window.gridSight.setEnabled(id, enabled)` for host pages
+  that want to build their own enrichment-chooser UI on top of the registry.
+- **Why**: The runtime toggle panel shipped in 012-capability-filtering is
+  intentionally opinionated — a fieldset of checkboxes. Some hosts will want
+  to render their own UI (a custom switch component, an integration with a
+  parent app's settings panel, etc.). Without a programmatic API they would
+  have to mutate the URL fragment by hand, which works but is not the kind
+  of stable contract the docs should promise.
+- **Context**: The effective-enabled-set module already exposes the resolver
+  and the cache; the new public method is a thin wrapper that updates the
+  visitor-persisted set, calls the resolver, runs tearDowns, and rebuilds
+  lozenges — exactly what the panel's `onCheckboxChange` does. The internal
+  function exists; this is just promoting one symbol to the public surface.
+- **Depends on / blocked by**: 012-capability-filtering shipping the
+  effective-enabled-set machinery and the panel as the reference consumer.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-[specs/001-dynamic-sliders/plan.md](specs/001-dynamic-sliders/plan.md)
+[specs/012-capability-filtering/plan.md](specs/012-capability-filtering/plan.md)
 <!-- SPECKIT END -->

--- a/specs/012-capability-filtering/checklists/requirements.md
+++ b/specs/012-capability-filtering/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Per-Page Enrichment Capability Filtering
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-19
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`
+- The spec deliberately uses the lozenge / enrichment terminology established by the
+  existing Grid-Sight codebase and specs 001–011 rather than introducing new vocabulary.
+- "Per-page" granularity (rather than per-table) is documented as a scoped assumption,
+  not a NEEDS CLARIFICATION, because the user explicitly framed the problem as
+  "configuring which capabilities are presented on a page" and existing tables can
+  already be excluded individually via `data-gs-ignore`.

--- a/specs/012-capability-filtering/contracts/public-api.md
+++ b/specs/012-capability-filtering/contracts/public-api.md
@@ -183,15 +183,23 @@ fixed` defaults that can be overridden by host CSS.
 
 ---
 
-## localStorage contract
+## localStorage contract (revised — matches existing slider precedent)
 
 | Key | Value | Notes |
 |---|---|---|
-| `gridsight:<url-stem>:enrichments` | JSON array of ids | Written every time the toggle panel changes. Read once at init if the URL fragment did not supply a value. |
+| `gs:<url-stem>:enrichments` | `{ "version": 1, "entries": ["heatmap","sliders",…] }` | Written every time the toggle panel changes. Read once at init if the URL fragment did not supply a value. |
 
-`<url-stem>` is identical to the stem used by the existing slider persistence
-(today: `location.origin + location.pathname`). Sharing the stem means clearing
-one page's GS state clears it for all features.
+- Prefix `gs:` is shared with the existing slider key `gs:<url-stem>:sliders`,
+  so a host clearing the `gs:` namespace clears all Grid-Sight state for that
+  page at once.
+- The payload is the same `PersistedState` versioned-wrapper shape the slider
+  persistence already defines; the only difference is that `entries` is a
+  `string[]` (id list) instead of a `Record<string, number>` (slider id →
+  position).
+- Unknown `version` values cause a fall-back to defaults rather than a throw
+  (mirrors slider behaviour).
+- `<url-stem>` is `location.origin + location.pathname`, matching the existing
+  per-URL persistence stem.
 
 ---
 
@@ -210,6 +218,20 @@ No errors are thrown for these cases; the library falls back to defaults.
 
 Unknown ids inside an otherwise-valid array are NOT warned about (this is the
 defined forward-compat path; warning would be noisy for legitimate use cases).
+
+### Runtime-panel resilience warnings
+
+In addition to init-time warnings, the runtime toggle panel emits these once
+each at the moment they happen (not once per init):
+
+| Condition | Console message |
+|---|---|
+| A registered `tearDown(table)` throws during a refresh | `[gridsight] tearDown(<id>) threw; continuing` (with the original error attached) |
+| The panel's container has been detached from the document since mount | `[gridsight] toggle panel container detached; panel disabled until next init()` |
+
+Both are warnings, not errors; the panel continues to function for any
+remaining tables after a tearDown throw, and quietly stops refreshing (and
+detaches its listeners) after a container detach.
 
 ---
 

--- a/specs/012-capability-filtering/contracts/public-api.md
+++ b/specs/012-capability-filtering/contracts/public-api.md
@@ -1,0 +1,224 @@
+# Public API Contract: Per-Page Enrichment Capability Filtering
+
+**Spec**: [../spec.md](../spec.md) · **Plan**: [../plan.md](../plan.md) · **Date**: 2026-05-19
+
+This contract documents every addition to the `window.gridSight` global surface,
+the `init()` options envelope, the host-page declarative surface (HTML
+attributes), the URL fragment grammar, and the DOM the runtime panel injects.
+
+Per the constitution Development-Phase Posture, names below are stable for this
+release but MAY change before the production cut; the frozen `init()` signature
+is preserved (the new options are additive).
+
+The existing `init`, `processTable`, `isValidTable`, `addSlider`,
+`addThresholdSlider`, `getSliders`, `removeAllSliders`, `registerFormula`, and
+`clearFormula` exports are unchanged.
+
+---
+
+## TypeScript signatures (informative)
+
+```ts
+// New types on the public surface.
+
+/** Stable identifier for one enrichment. Lowercase, hyphen-separated. */
+export type EnrichmentId = string;
+
+/** Page-level configuration object. Optional; absent means "use defaults". */
+export interface PageEnrichmentConfig {
+  /**
+   * The set of enrichments enabled on this page. When present, REPLACES the
+   * library default set (does not merge). Unknown ids are ignored.
+   * Empty array means "no enrichments" (master GS toggle still appears).
+   */
+  enrichments?: readonly EnrichmentId[];
+
+  /**
+   * When true, render the runtime visitor toggle panel. When omitted or false,
+   * no panel is rendered (unless the page contains a `[data-gs-toggle-panel]`
+   * container, which is treated as an equivalent declarative opt-in).
+   */
+  showToggleUi?: boolean;
+}
+
+/** Options for `gridSight.init()`. Extends the existing options envelope. */
+export interface InitOptions extends TableProcessorOptions {
+  /** Same semantics as `PageEnrichmentConfig.enrichments`. */
+  enrichments?: readonly EnrichmentId[];
+  /** Same semantics as `PageEnrichmentConfig.showToggleUi`. */
+  showToggleUi?: boolean;
+}
+
+declare global {
+  interface Window {
+    gridSight: {
+      // existing — unchanged
+      init(options?: InitOptions): typeof window.gridSight;
+      processTable(table: HTMLTableElement, options?: TableProcessorOptions): HTMLTableElement;
+      isValidTable(table: HTMLTableElement): boolean;
+
+      addSlider(table: HTMLTableElement, axis: "row" | "col"): GridSightSlider;
+      addThresholdSlider(table: HTMLTableElement): GridSightSlider;
+      getSliders(table?: HTMLTableElement): GridSightSlider[];
+      removeAllSliders(table?: HTMLTableElement): void;
+      registerFormula(table: HTMLTableElement, fn: FormulaFn): void;
+      clearFormula(table: HTMLTableElement): void;
+
+      // NEW — page-level config (read at init() time)
+      pageConfig?: PageEnrichmentConfig;
+
+      // NEW — read-only view of the registry, for host inspection / debugging
+      readonly enrichmentIds: readonly EnrichmentId[];
+
+      // NEW — read-only view of the currently effective enabled set
+      isEnrichmentEnabled(id: EnrichmentId): boolean;
+    };
+  }
+}
+```
+
+---
+
+## Behavioural contract
+
+### `window.gridSight.pageConfig`
+
+**Authoring contract**: The page author assigns this property **before** calling
+`init()`. The assignment may live in a `<script>` tag in `<head>` or anywhere in
+`<body>` that runs before init. Reading the property after init returns the
+same value that was stored; mutating it post-init has no effect on the running
+session (a future init() call would pick up the new value).
+
+**Library contract**: At init, the library reads `pageConfig` once, normalises
+it via `core/page-config.ts`, and caches the result. The original property is
+left untouched (for debugging).
+
+### `gridSight.init(options)`
+
+When called with `options.enrichments` and/or `options.showToggleUi`, those
+values take precedence over `window.gridSight.pageConfig` for the same fields.
+Fields not present in `options` fall back to `pageConfig`; fields absent from
+both fall back to defaults.
+
+- **Pre**: `options` is omitted or an object. `options.enrichments` if present
+  is an array. `options.showToggleUi` if present is a boolean.
+- **Post**: The library is initialised; for every qualifying table, only the
+  effective enabled set's lozenges are rendered. If `showToggleUi` resolves
+  truthy (or a `[data-gs-toggle-panel]` element exists on the page), the
+  runtime panel is mounted exactly once.
+- **Errors**: Same as today (`Failed to inject UI elements` warnings on a
+  per-table basis). Misshapen `enrichments` arrays do NOT throw — a single
+  console warning is emitted and the field is ignored (FR-022).
+
+### `window.gridSight.enrichmentIds`
+
+A frozen, read-only array of every registered enrichment id, in registry
+display order. Useful for host pages that want to render their own enrichment
+chooser (rare, but supported).
+
+### `window.gridSight.isEnrichmentEnabled(id)`
+
+Returns `true` if `id` is in the current effective enabled set, otherwise
+`false` (including for ids the registry does not know).
+
+- **Pre**: `id` is a string.
+- **Post**: Pure read. Safe to call from outside the library, including from
+  inside `tearDown` hooks.
+
+---
+
+## HTML declarative surface (host-page facing)
+
+| Selector / attribute | Purpose |
+|---|---|
+| `[data-gs-toggle-panel]` | Container element into which the runtime toggle panel mounts. Existence of this element opts in to the panel even without `showToggleUi: true`. |
+| `[data-gs-ignore]` (existing) | Unchanged. A table marked thus is untouched by Grid-Sight regardless of `enrichments` config. |
+
+The panel itself injects this DOM:
+
+```html
+<fieldset data-gs-toggle-panel-root>
+  <legend>Grid-Sight enrichments</legend>
+  <label data-gs-enrichment-toggle="heatmap">
+    <input type="checkbox" /> Heatmap <span class="gs-id-hint">(heatmap)</span>
+  </label>
+  <label data-gs-enrichment-toggle="sliders">
+    <input type="checkbox" /> Sliders <span class="gs-id-hint">(sliders)</span>
+  </label>
+  <!-- one row per registered id -->
+</fieldset>
+```
+
+| Selector | Purpose |
+|---|---|
+| `[data-gs-toggle-panel-root]` | The panel's root fieldset. Stable selector for host CSS. |
+| `[data-gs-enrichment-toggle="<id>"]` | One label per registered enrichment. The attribute carries the id for inspection / e2e selectors. |
+| `.gs-id-hint` | The small `(id)` annotation after the label. Host CSS can hide it. |
+
+CSS variables exposed:
+
+| Variable | Scope | Meaning |
+|---|---|---|
+| `--gs-toggle-panel-bg` | `[data-gs-toggle-panel-root]` | Override background. |
+| `--gs-toggle-panel-border` | `[data-gs-toggle-panel-root]` | Override border colour. |
+
+The panel's own positional CSS (top-right dock when no container is supplied)
+is applied via the same `data-gs-toggle-panel-root` selector with `position:
+fixed` defaults that can be overridden by host CSS.
+
+---
+
+## URL contract
+
+`#gs.e=<id>[,<id>]*`
+
+- `id` matches `/^[a-z][a-z0-9-]*$/`.
+- Multiple ids comma-separated, written in alphabetical order on persist.
+- Unknown ids on load are silently ignored (forward-compat for older bookmarks
+  pointing at enrichments this build no longer ships).
+- Malformed fragments are ignored as a whole; falls back to localStorage.
+- The `gs.e` segment is independent of the existing `gs.s` slider segment;
+  they can appear together: `#gs.s=...&gs.e=...` (the `&` separator is the
+  same as the slider key already uses).
+
+---
+
+## localStorage contract
+
+| Key | Value | Notes |
+|---|---|---|
+| `gridsight:<url-stem>:enrichments` | JSON array of ids | Written every time the toggle panel changes. Read once at init if the URL fragment did not supply a value. |
+
+`<url-stem>` is identical to the stem used by the existing slider persistence
+(today: `location.origin + location.pathname`). Sharing the stem means clearing
+one page's GS state clears it for all features.
+
+---
+
+## Diagnostics / console output
+
+The library emits at most these warnings, each at most once per init:
+
+| Condition | Console message |
+|---|---|
+| `pageConfig.enrichments` is not an array | `[gridsight] pageConfig.enrichments must be an array; ignoring.` |
+| `pageConfig.enrichments` contains non-string entries | `[gridsight] pageConfig.enrichments contains non-string entries; dropping.` |
+| `pageConfig.showToggleUi` is not a boolean | `[gridsight] pageConfig.showToggleUi must be a boolean; coercing.` |
+| `pageConfig` is the wrong shape entirely | `[gridsight] pageConfig must be an object; ignoring.` |
+
+No errors are thrown for these cases; the library falls back to defaults.
+
+Unknown ids inside an otherwise-valid array are NOT warned about (this is the
+defined forward-compat path; warning would be noisy for legitimate use cases).
+
+---
+
+## Versioning note
+
+Per the constitution Development-Phase Posture, none of the symbols above
+(`pageConfig`, `enrichmentIds`, `isEnrichmentEnabled`, `data-gs-toggle-panel*`,
+the `gs.e` URL key) are under SemVer freeze. The frozen public contract is
+still only `init`'s signature, which this feature extends additively (new
+optional fields on the options envelope — no breakage). Once the production
+cut happens, this surface (or whatever it has evolved into) will be amended
+into the constitution's "Public API surface" list and frozen.

--- a/specs/012-capability-filtering/data-model.md
+++ b/specs/012-capability-filtering/data-model.md
@@ -15,7 +15,7 @@ externally-observable shape is the page-config (see `contracts/public-api.md`).
 The single in-library record of every enrichment the build ships, keyed by
 stable identifier.
 
-### Fields
+### Registry fields
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
@@ -24,7 +24,7 @@ stable identifier.
 | `defaultOn` | `boolean` | yes | Whether this enrichment is in the default enabled set when no page config or visitor override is present. Today every entry is `true` (FR-001 preserves pre-feature behaviour). |
 | `tearDown` | `(table: HTMLTableElement) => void` | optional | Cleanup hook called when the enrichment transitions enabled → disabled while at least one of its instances is live on the page. Optional because some enrichments (e.g. `statistics` popup) clean up via a dismiss on `window._gs*Popup` rather than needing a hook. |
 
-### Validation rules
+### Registry validation rules
 
 - `id` MUST match `/^[a-z][a-z0-9-]*$/`. Validated at registry-construction time
   (compile-time error in TS; runtime assertion at boot).
@@ -34,7 +34,7 @@ stable identifier.
   clean up; it MUST handle the case where no instance of the enrichment is
   currently active on `table` (i.e. it must be idempotent).
 
-### Lifecycle
+### Registry lifecycle
 
 - Constructed once at module load (`src/core/enrichment-registry.ts`).
 - Frozen (`Object.freeze`) after construction; treated as read-only by everything
@@ -76,14 +76,14 @@ instances to clean up yet; each enrichment's implementation PR adds its own
 The author-supplied, page-scoped declaration of which enrichments are enabled
 for one HTML page.
 
-### Fields
+### Config fields
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
 | `enrichments` | `string[]` | optional | The page-level enabled set. When present, replaces the library defaults entirely (FR-005). When absent, defaults apply. Empty array is a valid value (FR edge case: "no enrichments"). |
 | `showToggleUi` | `boolean` | optional | When `true`, opt in to the runtime visitor toggle panel (FR-013). Default `false`. |
 
-### Validation rules
+### Config validation rules
 
 - The whole config is optional. Absent → use defaults.
 - `enrichments` MUST be an array if present. Non-array values trigger a single
@@ -176,7 +176,7 @@ visitor flip each on or off.
 | `refresh()` | Set each checkbox `checked` to match the current effective set. Called after any external mutation (today: never, but kept for future symmetry). |
 | `onCheckboxChange(id, checked)` | Mutate the visitor-persisted set: add or remove `id`. Re-derive the effective set. Run tearDowns for any id that just went off. Call the global lozenge rebuild for every registered table. |
 
-### Lifecycle
+### Panel lifecycle
 
 - Created only when `pageConfig.showToggleUi === true` **or** the page contains
   a `<* data-gs-toggle-panel>` element (FR-013 + R-5).

--- a/specs/012-capability-filtering/data-model.md
+++ b/specs/012-capability-filtering/data-model.md
@@ -212,7 +212,12 @@ the resolver and the toggle panel.
 
 ---
 
-## Persistence shape
+## Persistence shape (revised after review fix 1A)
+
+The enrichments-toggle persistence shares helpers with the existing slider
+persistence in `src/utils/slider-persistence.ts` rather than duplicating its
+idioms. This section documents the resulting on-the-wire and on-disk shapes,
+which match the slider precedent exactly.
 
 URL fragment key (consistent with existing `gs.s`):
 
@@ -224,16 +229,39 @@ URL fragment key (consistent with existing `gs.s`):
 - No spaces.
 - Alphabetical order on write (stable bookmark diff).
 - Unknown ids and malformed entries are ignored on read (FR-007 / FR-022).
+- Coexists in the hash with other `&`-separated GS keys (e.g. `gs.s=`); the
+  parser is the same `readFromUrl(key, hash?)` helper that the slider code
+  uses today.
 
 `localStorage` key:
 
 ```text
-gridsight:<url-stem>:enrichments  →  ["heatmap","sliders","statistics"]
+gs:<url-stem>:enrichments  →  { "version": 1, "entries": ["heatmap","sliders","statistics"] }
 ```
 
-`<url-stem>` is the existing stem used by sliders — typically
-`location.origin + location.pathname` (no query, no fragment), matching the
-project's per-URL persistence model.
+- Prefix `gs:` matches the existing slider key (`gs:<url-stem>:sliders`).
+- Payload is the same `PersistedState` versioned wrapper the slider code
+  defines (`{ version: number, entries: ... }`). Slider entries are a
+  `Record<string, number>`; enrichment entries are a `string[]` (the id
+  list). The wrapper itself is shared.
+- Unknown `version` values cause a fall-back to defaults (mirrors slider
+  precedent — no throw).
+- `<url-stem>` is the existing stem used by sliders — typically
+  `location.origin + location.pathname` (no query, no fragment).
+
+Helpers used (after the slider-persistence refactor described in research
+R-4):
+
+| Helper | New signature | Used for |
+|---|---|---|
+| `urlStem()` | unchanged | derives the per-URL stem |
+| `readFromUrl(key, hash?)` | parameterised by `key` | reads either `gs.s` or `gs.e` from the same hash |
+| `writeUrlHash(key, encoded, hash?)` | parameterised by `key` | writes either `gs.s=` or `gs.e=` while preserving the other |
+| `readFromStorage(suffix, stem?)` | parameterised by `suffix` | reads `gs:<stem>:sliders` or `gs:<stem>:enrichments` |
+| `writeToStorage(suffix, payload, stem?)` | parameterised by `suffix` | writes either key with the versioned wrapper |
+
+No new persistence module is created; `utils/enrichment-persistence.ts` is
+**removed** from the proposed file list (replaced by the refactor).
 
 ---
 

--- a/specs/012-capability-filtering/data-model.md
+++ b/specs/012-capability-filtering/data-model.md
@@ -1,0 +1,250 @@
+# Data Model: Per-Page Enrichment Capability Filtering
+
+**Spec**: [./spec.md](./spec.md) · **Plan**: [./plan.md](./plan.md) · **Date**: 2026-05-19
+
+Four entities. Three of them are pure data structures with no methods; the
+fourth (`RuntimeTogglePanel`) is a small stateful UI component. All names are
+TypeScript-style for clarity but the data could equally be expressed in any
+language with a similar type system. None of this is wire-format; the only
+externally-observable shape is the page-config (see `contracts/public-api.md`).
+
+---
+
+## EnrichmentRegistry
+
+The single in-library record of every enrichment the build ships, keyed by
+stable identifier.
+
+### Fields
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `id` | `string` | yes | Lower-case, hyphen-separated. Stable identifier; never renamed without a registry-wide review (per Development-Phase Posture, free to evolve before the production cut). Matches the `data-gs-lozenge-id` attribute the DOM already exposes for shipped lozenges. |
+| `label` | `string` | yes | Human-readable label used in the runtime toggle panel. May be localised in a future release; today, English only. |
+| `defaultOn` | `boolean` | yes | Whether this enrichment is in the default enabled set when no page config or visitor override is present. Today every entry is `true` (FR-001 preserves pre-feature behaviour). |
+| `tearDown` | `(table: HTMLTableElement) => void` | optional | Cleanup hook called when the enrichment transitions enabled → disabled while at least one of its instances is live on the page. Optional because some enrichments (e.g. `statistics` popup) clean up via a dismiss on `window._gs*Popup` rather than needing a hook. |
+
+### Validation rules
+
+- `id` MUST match `/^[a-z][a-z0-9-]*$/`. Validated at registry-construction time
+  (compile-time error in TS; runtime assertion at boot).
+- `id` MUST be unique within the registry.
+- `label` MUST be non-empty.
+- `tearDown` MUST NOT throw. It MAY be a no-op if the enrichment has nothing to
+  clean up; it MUST handle the case where no instance of the enrichment is
+  currently active on `table` (i.e. it must be idempotent).
+
+### Lifecycle
+
+- Constructed once at module load (`src/core/enrichment-registry.ts`).
+- Frozen (`Object.freeze`) after construction; treated as read-only by everything
+  downstream.
+- Adding a new enrichment in future means **one edit** to the registry array.
+
+### Initial contents
+
+In display order (alphabetised among future-only ids):
+
+```ts
+[
+  { id: 'heatmap',          label: 'Heatmap',          defaultOn: true, tearDown: removeAllHeatmaps },
+  { id: 'sliders',          label: 'Sliders',          defaultOn: true, tearDown: removeAllAxisSliders },
+  { id: 'slider-threshold', label: 'Threshold slider', defaultOn: true, tearDown: removeThresholdSliders },
+  { id: 'statistics',       label: 'Statistics popup', defaultOn: true, tearDown: dismissStatisticsPopup },
+  { id: 'frequency',        label: 'Frequency table',  defaultOn: true, tearDown: dismissFrequencyDialog },
+  { id: 'frequency-chart',  label: 'Frequency chart',  defaultOn: true, tearDown: dismissFrequencyChartDialog },
+  { id: 'annotations',      label: 'Cell annotations', defaultOn: true },   // spec 006 — no tearDown until shipped
+  { id: 'copy-as-csv',      label: 'Copy as CSV',      defaultOn: true },   // spec 009
+  { id: 'cumulative',       label: 'Cumulative col.',  defaultOn: true },   // spec 008
+  { id: 'diff-compare',     label: 'Diff / compare',   defaultOn: true },   // spec 010
+  { id: 'filter',           label: 'Column filter',    defaultOn: true },   // spec 003
+  { id: 'outlier',          label: 'Outlier marker',   defaultOn: true },   // spec 004
+  { id: 'sort',             label: 'Column sort',      defaultOn: true },   // spec 002
+  { id: 'sparkline',        label: 'Row sparkline',    defaultOn: true },   // spec 005
+  { id: 'units-toggle',     label: 'Units toggle',     defaultOn: true },   // spec 007
+]
+```
+
+Spec-only entries register with no `tearDown` because they have no live
+instances to clean up yet; each enrichment's implementation PR adds its own
+`tearDown` to the registry entry as it lands.
+
+---
+
+## PageEnrichmentConfig
+
+The author-supplied, page-scoped declaration of which enrichments are enabled
+for one HTML page.
+
+### Fields
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `enrichments` | `string[]` | optional | The page-level enabled set. When present, replaces the library defaults entirely (FR-005). When absent, defaults apply. Empty array is a valid value (FR edge case: "no enrichments"). |
+| `showToggleUi` | `boolean` | optional | When `true`, opt in to the runtime visitor toggle panel (FR-013). Default `false`. |
+
+### Validation rules
+
+- The whole config is optional. Absent → use defaults.
+- `enrichments` MUST be an array if present. Non-array values trigger a single
+  console warning and the entire config is rejected (FR-022).
+- Entries within `enrichments` SHOULD be strings; non-string entries are dropped
+  with a warning. The remaining valid entries are honoured.
+- String entries are normalised: lower-cased and trimmed before lookup
+  (FR Edge Case: case-insensitive, dedup). Unknown ids (after normalisation)
+  are silently dropped (FR-007).
+- `showToggleUi` MUST be a boolean if present. Non-booleans are coerced via
+  `Boolean()` and emit a warning.
+
+### Entry points
+
+- `window.gridSight.pageConfig = { enrichments: [...], showToggleUi: true }` —
+  IIFE / `<script>` path. Read at `init()` time.
+- `gridSight.init({ enrichments: [...], showToggleUi: true })` — ESM path.
+  The options shape extends the existing `TableProcessorOptions` envelope.
+
+Whichever path is used, the parser produces the same internal normalised shape:
+`{ enrichments: Set<string> | undefined, showToggleUi: boolean }`. `enrichments`
+is `undefined` when the field was absent and an empty `Set` when the field was
+present but empty (the two cases mean different things — see FR Edge Case).
+
+---
+
+## EffectiveEnabledSet
+
+The resolved set of enrichment ids active for a given page-visit. Computed once
+at `init()` and re-computed on every visitor toggle.
+
+### Shape
+
+`Set<string>` — a JS `Set` of normalised ids.
+
+### Inputs
+
+1. `visitorOverride: Set<string> | undefined` — from the visitor's persisted
+   toggle state (URL fragment > localStorage). `undefined` means no visitor
+   override (the panel hasn't been used, or the page didn't opt in to it).
+2. `pageConfig: { enrichments: Set<string> | undefined, ... }` — normalised
+   page-config from above.
+3. `registry: EnrichmentRegistry[]` — for default resolution and id validity.
+
+### Resolution algorithm
+
+```text
+if visitorOverride is defined:
+    return new Set(visitorOverride ∩ knownIds)
+if pageConfig.enrichments is defined:
+    return new Set(pageConfig.enrichments ∩ knownIds)
+return new Set(registry.filter(e => e.defaultOn).map(e => e.id))
+```
+
+`knownIds` is derived from the registry; intersection guarantees unknown ids
+are dropped before any downstream consumer sees them. The result is always a
+fresh `Set` — no aliasing of input collections.
+
+### Where it lives
+
+- Held in a module-scoped variable in `src/core/effective-enabled-set.ts`.
+- Re-derived by `init()` and by the toggle panel's `change` handler.
+- Read by:
+  - `src/ui/header-utils.ts` — filters `LozengeSpec[]` before lozenge construction.
+  - `src/ui/enrichment-menu.ts` — filters menu items.
+  - Persistence loaders — skip URL-encoded state for disabled enrichments
+    (FR-011).
+  - Each enrichment's "register" point at table-processing time, if present.
+
+---
+
+## RuntimeTogglePanel
+
+An opt-in UI component that lists every registered enrichment and lets the
+visitor flip each on or off.
+
+### State
+
+| Field | Type | Notes |
+|---|---|---|
+| `root` | `HTMLFieldSetElement` | The panel's DOM root. One per page. |
+| `checkboxes` | `Map<string, HTMLInputElement>` | id → checkbox, for fast state mirroring. |
+| `mounted` | `boolean` | True after `mount()` has run; idempotent. |
+
+### Operations
+
+| Operation | Purpose |
+|---|---|
+| `mount(container?)` | Build DOM, append to `container` (or `[data-gs-toggle-panel]`, or `<body>`). Read current effective set, set each checkbox accordingly. Wire `change` listeners. Idempotent. |
+| `refresh()` | Set each checkbox `checked` to match the current effective set. Called after any external mutation (today: never, but kept for future symmetry). |
+| `onCheckboxChange(id, checked)` | Mutate the visitor-persisted set: add or remove `id`. Re-derive the effective set. Run tearDowns for any id that just went off. Call the global lozenge rebuild for every registered table. |
+
+### Lifecycle
+
+- Created only when `pageConfig.showToggleUi === true` **or** the page contains
+  a `<* data-gs-toggle-panel>` element (FR-013 + R-5).
+- Never unmounted during a page's lifetime; reload destroys it along with the
+  rest of the page.
+
+### Accessibility
+
+See research entry R-9. The panel uses native `<fieldset>`, `<legend>`,
+`<label>`, and `<input type="checkbox">`; no custom ARIA roles.
+
+---
+
+## Relationships
+
+```text
+EnrichmentRegistry (read-only, module scope)
+        ▲
+        │ knownIds, defaults
+        │
+        ▼
+EffectiveEnabledSet ◀──── PageEnrichmentConfig (parsed once)
+        ▲
+        │ writes by user action
+        │
+RuntimeTogglePanel ────── reads visitor persisted state
+                          (URL fragment + localStorage)
+```
+
+Every downstream consumer (lozenge builder, menu builder, URL-state loader)
+reads from `EffectiveEnabledSet`. Nothing reads the registry directly except
+the resolver and the toggle panel.
+
+---
+
+## Persistence shape
+
+URL fragment key (consistent with existing `gs.s`):
+
+```text
+#gs.e=heatmap,sliders,statistics
+```
+
+- Ids comma-separated.
+- No spaces.
+- Alphabetical order on write (stable bookmark diff).
+- Unknown ids and malformed entries are ignored on read (FR-007 / FR-022).
+
+`localStorage` key:
+
+```text
+gridsight:<url-stem>:enrichments  →  ["heatmap","sliders","statistics"]
+```
+
+`<url-stem>` is the existing stem used by sliders — typically
+`location.origin + location.pathname` (no query, no fragment), matching the
+project's per-URL persistence model.
+
+---
+
+## Out of scope (documented for future readers)
+
+- **Per-table override**: not in this feature. If demanded later, the natural
+  extension is `data-gs-enrichments="..."` on `<table>` that produces a
+  per-table `EffectiveEnabledSet`.
+- **Localised labels**: registry `label` is English-only today. Future
+  feature: `labels: { en: '...', fr: '...' }`.
+- **Programmatic toggling from host JS** (e.g. `gridSight.setEnabled('sort',
+  true)`): not exposed yet. Trivially implementable on top of the resolver if
+  needed; intentionally absent from this feature's public API to keep the
+  surface narrow.

--- a/specs/012-capability-filtering/plan.md
+++ b/specs/012-capability-filtering/plan.md
@@ -1,0 +1,151 @@
+# Implementation Plan: Per-Page Enrichment Capability Filtering
+
+**Branch**: `claude/add-capability-filtering-dTXwp` | **Date**: 2026-05-19 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/012-capability-filtering/spec.md`
+
+## Summary
+
+Introduce a single in-library **enrichment registry** that names every Grid-Sight
+enrichment by a stable identifier (`heatmap`, `sliders`, `sort`, …) and records its
+default-on flag and human-readable label. Pages opt into a narrower set by declaring
+`window.gridSight.pageConfig.enrichments` (or passing `enrichments` to `init()`)
+**before** Grid-Sight initialises. The lozenge-spec assembly in `src/ui/header-utils.ts`
+consults the resolved enabled set and filters out specs whose `id` is not in it; the
+result is that disabled enrichments leave **no** lozenge, **no** menu entry, and
+**no** URL-state activation. A second, opt-in **runtime toggle panel** lets a visitor
+flip enrichments on and off live; its state persists per URL stem via the existing
+fragment + `localStorage` model already shared by sliders and (in spec) sort, and
+takes precedence over the static page config for that visitor. Every existing demo
+page is updated to declare an explicit subset; one new demo (`public/demo/toggle/`)
+showcases the runtime panel. No new runtime dependencies; net bundle growth ≤ 1 KB
+gzipped (constitution §I).
+
+## Technical Context
+
+**Language/Version**: TypeScript ~5.8 (existing project compiler version; output ES2020+)
+**Primary Dependencies**:
+  - Runtime: none new. Existing `simple-statistics`, `shepherd.js` unrelated to this feature.
+  - Build/test: existing Vite 6, Vitest 3, Playwright 1.53, Storybook 9 (unchanged).
+**Storage**: `window.localStorage` (existing per-URL-stem persistence) plus URL fragment
+  params for visitor-set enabled set.
+**Testing**: Vitest unit tests in `src/**/__tests__/`, Storybook 9 interaction tests
+  via `@storybook/addon-vitest`, Playwright e2e under `tests/e2e/`.
+**Target Platform**: Evergreen browsers ≤ 2 years old (Chrome, Firefox, Safari, Edge,
+  Chromium derivatives). Must function from `file://` (offline).
+**Project Type**: Browser library, single project. IIFE bundle (`grid-sight.iife.js`)
+  + npm/ESM via `src/index.ts` entry.
+**Performance Goals**:
+  - Filter check at lozenge-spec build time: O(1) `Set` lookup per candidate spec.
+  - Runtime toggle: lozenge add / remove + cleanup completes within one animation
+    frame (≤ 16 ms) on a mid-range laptop (SC-004).
+  - No re-layout cost beyond the lozenge mutation itself; no full re-process of
+    table data.
+**Constraints**:
+  - Net bundle delta ≤ 1 KB gzipped for the whole feature (SC-007 + constitution §I).
+  - Runtime toggle panel is opt-in per page but its **code** is part of the bundle;
+    it must be tight enough to fit within the 1 KB total.
+  - No runtime network access (constitution §VI). No new deps.
+  - Keyboard + AT operability for the panel (FR-021 + constitution §III).
+  - Per-URL-stem persistence model unchanged.
+**Scale/Scope**: Same as host-page scope — up to ~10 tables per page, up to ~14
+  registered enrichment ids today (room to grow). Toggle panel lists every
+  registered id; expected list length 10–20 over the next year.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Evaluated against `.specify/memory/constitution.md` v1.1.0:
+
+| Principle | Verdict | Notes |
+|-----------|---------|-------|
+| I. Lightweight & Minimal Dependencies | ✅ Pass | No new runtime deps. Net additions targeted ≤ 1 KB gzipped (SC-007); measured each PR. |
+| II. Test Discipline | ✅ Pass | Vitest unit tests for registry resolution / config parsing / persistence; Storybook interaction tests for the toggle panel; Playwright e2e for one demo subset and the live-toggle demo. |
+| III. Accessibility by Default | ✅ Pass | Toggle panel uses native `<input type="checkbox">` with associated `<label>`; arrow/tab focus order; `aria-live` not required since each control's state is conveyed by the checkbox itself. No colour-only signalling. |
+| IV. Progressive Enhancement | ✅ Pass | Pages without a page-config behave exactly as today (FR-008). Toggle panel is opt-in (FR-013); pages that do not request it pay only the bundle cost. Library still works as IIFE drop-in and as ESM. |
+| V. Cross-Browser Compatibility | ✅ Pass | `Set`, `URLSearchParams`, `localStorage`, native checkboxes all available in evergreen ≤ 2 years. No new APIs guarded. |
+| VI. Offline-First / Air-Gapped | ✅ Pass | All logic client-side. URL + localStorage persistence uses already-resident state. No fetches. |
+| Development-Phase Posture | N/A | Pre-production; backwards-compat freeze does not apply. `window.gridSight.pageConfig` is a new surface introduced explicitly under the waiver. |
+
+**No constitution violations.** Complexity Tracking section below is intentionally empty.
+
+**Post-design re-check (2026-05-19)**: After producing `research.md`, `data-model.md`,
+`contracts/public-api.md`, and `quickstart.md`, the Constitution Check was
+re-evaluated. Bundle estimate (R-7) is ~0.7 KB gzipped — under the 1 KB feature
+budget. No new runtime dependencies introduced. All behaviour stays client-side
+(constitution §VI). Verdict: still passing on every principle.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/012-capability-filtering/
+├── plan.md              # This file
+├── spec.md              # Feature specification (input)
+├── research.md          # Phase 0 — decisions on registry shape, config surface, panel, persistence
+├── data-model.md        # Phase 1 — EnrichmentRegistry, PageEnrichmentConfig, EffectiveEnabledSet
+├── quickstart.md        # Phase 1 — wire a subset into a host page in <5 min
+├── contracts/
+│   └── public-api.md    # Phase 1 — new window.gridSight.pageConfig + init() option surface
+├── checklists/
+│   └── requirements.md  # Spec validation (already passing)
+└── tasks.md             # Phase 2 output — created by /speckit-tasks (not by /speckit-plan)
+```
+
+### Source Code (repository root)
+
+The existing single-project layout is reused. Filtering concerns are concentrated in
+one new core module + one new UI module, with a small change to the lozenge-spec
+assembly in `src/ui/header-utils.ts`.
+
+```text
+src/
+├── core/
+│   ├── enrichment-registry.ts        # NEW — canonical id → { label, defaultOn, tearDown? }
+│   ├── enrichment-registry.test.ts   # via __tests__/
+│   ├── page-config.ts                # NEW — reads window.gridSight.pageConfig + init() options
+│   └── effective-enabled-set.ts      # NEW — resolves visitor > page > defaults
+├── ui/
+│   ├── header-utils.ts               # MODIFIED — filter LozengeSpec[] by effective enabled set
+│   ├── toggle-panel.ts               # NEW — opt-in runtime visitor toggle UI
+│   └── enrichment-menu.ts            # MODIFIED — filter menu items by effective enabled set
+├── utils/
+│   └── enrichment-persistence.ts     # NEW — URL fragment ↔ localStorage for visitor toggle set
+├── core/__tests__/
+│   ├── enrichment-registry.test.ts   # NEW
+│   ├── page-config.test.ts           # NEW
+│   └── effective-enabled-set.test.ts # NEW
+├── ui/__tests__/
+│   └── toggle-panel.test.ts          # NEW (Storybook + interaction)
+├── utils/__tests__/
+│   └── enrichment-persistence.test.ts # NEW
+├── stories/
+│   └── TogglePanel.stories.ts        # NEW
+└── index.ts                          # MODIFIED — read pageConfig at init; expose pageConfig type
+
+tests/e2e/
+├── capability-filtering.spec.ts      # NEW — Story 1 + Story 3 (demo subsets)
+└── capability-filtering-toggle.spec.ts # NEW — Story 2 (live toggle + persistence)
+
+public/demo/
+├── atmosphere.html, ...              # MODIFIED — each existing demo declares an explicit subset
+└── toggle/                           # NEW
+    └── live-enrichments.html         # NEW — runtime toggle demo (Story 2 / FR-020)
+```
+
+**Structure Decision**: Single-project layout, additive. The registry is the single
+new source of truth; the page-config and effective-set resolvers are stateless pure
+functions sized for unit testing. The filter integration into `header-utils.ts` is a
+two-line change inside the existing spec-collection loop, so the existing lozenge
+tests continue to cover the happy path and the new unit tests cover the filter
+semantics in isolation. The toggle panel sits in its own module so it does not bleed
+into pages that don't opt in to it.
+
+## Complexity Tracking
+
+> *No constitution violations identified. Section intentionally empty.*
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| — | — | — |

--- a/specs/012-capability-filtering/plan.md
+++ b/specs/012-capability-filtering/plan.md
@@ -10,15 +10,29 @@ enrichment by a stable identifier (`heatmap`, `sliders`, `sort`, …) and record
 default-on flag and human-readable label. Pages opt into a narrower set by declaring
 `window.gridSight.pageConfig.enrichments` (or passing `enrichments` to `init()`)
 **before** Grid-Sight initialises. The lozenge-spec assembly in `src/ui/header-utils.ts`
-consults the resolved enabled set and filters out specs whose `id` is not in it; the
-result is that disabled enrichments leave **no** lozenge, **no** menu entry, and
-**no** URL-state activation. A second, opt-in **runtime toggle panel** lets a visitor
-flip enrichments on and off live; its state persists per URL stem via the existing
-fragment + `localStorage` model already shared by sliders and (in spec) sort, and
-takes precedence over the static page config for that visitor. Every existing demo
-page is updated to declare an explicit subset; one new demo (`public/demo/toggle/`)
+and the menu-item filter in `src/ui/enrichment-menu.ts` both consult the resolved
+enabled set and filter out specs whose `id` is not in it; the result is that
+disabled enrichments leave **no** lozenge, **no** menu entry, and **no** URL-state
+activation. A second, opt-in **runtime toggle panel** lets a visitor flip
+enrichments on and off live; its state persists per URL stem by sharing the
+existing `src/utils/slider-persistence.ts` helpers (URL fragment `gs.e=…` and
+`localStorage` key `gs:<stem>:enrichments` with the existing `{ version, entries }`
+wrapper) and takes precedence over the static page config for that visitor. The
+existing five demo pages (`public/demo/index.html` and the four `public/demo/sliders/*`)
+each declare an explicit subset; one new demo (`public/demo/toggle/live-enrichments.html`)
 showcases the runtime panel. No new runtime dependencies; net bundle growth ≤ 1 KB
-gzipped (constitution §I).
+gzipped, enforced by re-hardening the existing `scripts/bundle-size.js` (constitution §I).
+
+Review fixes folded into this revision (see research R-1.1, revised R-4, new R-10,
+new R-11): align `EnrichmentType` ids in `enrichment-menu.ts` with the registry
+(rename `slider` → `sliders`, `threshold-slider` → `slider-threshold`, collapse
+`toggle-sliders` into `sliders`, retire `zscore`/`aggregate`); share slider
+persistence helpers rather than duplicate them; cache per-table column types via a
+WeakMap so the refresh path is bounded by header count, not cell count; wrap every
+`tearDown(table)` call in try/catch and emit a single console warning on throw;
+abort runtime refresh and detach listeners when the panel's container becomes
+detached from the document; re-enable the 10 KB gzipped ceiling in
+`scripts/bundle-size.js` and surface the current bundle baseline before merging.
 
 ## Technical Context
 
@@ -75,6 +89,37 @@ re-evaluated. Bundle estimate (R-7) is ~0.7 KB gzipped — under the 1 KB featur
 budget. No new runtime dependencies introduced. All behaviour stays client-side
 (constitution §VI). Verdict: still passing on every principle.
 
+**Post-review re-check (2026-05-19, after `/speckit-review` Compressed mode and
+revisions 1A/2A/3A/4A + three failure-mode guards)**: The Constitution Check
+was re-evaluated against the revised plan.
+
+- **Principle I (Lightweight)**: bundle estimate revised to ~0.89 KB gzipped
+  (R-7) — still under the 1 KB feature target. Enforcement of the 10 KB
+  absolute ceiling moves from "informational" back to a hard gate by editing
+  the existing `scripts/bundle-size.js` (R-11). Pass — with the open question
+  that the implementation PR MUST measure the current bundle and either
+  bundle-cut to <10 KB or land an explicit constitution amendment before
+  flipping enforcement on.
+- **Principle II (Test Discipline)**: two new test files added in this
+  revision (`enrichment-menu-filter.test.ts`, `header-utils.refresh.test.ts`)
+  close the FR-010 acceptance gap and the column-types-cache coverage gap.
+  Bundle-size assertion (3A / R-11) closes the silent-failure gap on the
+  bundle ceiling. Pass.
+- **Principle III (Accessibility)**: unchanged. Pass.
+- **Principle IV (Progressive Enhancement)**: unchanged; the
+  container-resilience guard (R-5 addition) makes the panel safer in SPA
+  hosts. Pass.
+- **Principle V (Cross-Browser)**: `WeakMap` (R-10) is available in evergreen
+  ≤ 2 years. Pass.
+- **Principle VI (Offline-First)**: unchanged. Pass.
+- **Development-Phase Posture**: the `EnrichmentType` rename in
+  `enrichment-menu.ts` (R-1.1) is a breaking change to internal types, which
+  the posture explicitly waives. Pass.
+
+Verdict: still passing on every principle. One open question (R-11 — current
+bundle baseline vs the 10 KB ceiling at the moment enforcement is flipped on)
+is recorded for the implementation task list rather than blocking the plan.
+
 ## Project Structure
 
 ### Documentation (this feature)
@@ -103,44 +148,64 @@ assembly in `src/ui/header-utils.ts`.
 src/
 ├── core/
 │   ├── enrichment-registry.ts        # NEW — canonical id → { label, defaultOn, tearDown? }
-│   ├── enrichment-registry.test.ts   # via __tests__/
 │   ├── page-config.ts                # NEW — reads window.gridSight.pageConfig + init() options
-│   └── effective-enabled-set.ts      # NEW — resolves visitor > page > defaults
+│   ├── effective-enabled-set.ts      # NEW — resolves visitor > page > defaults
+│   └── column-types-cache.ts         # NEW (review fix 4A) — WeakMap<HTMLTableElement, ColumnType[]>
 ├── ui/
-│   ├── header-utils.ts               # MODIFIED — filter LozengeSpec[] by effective enabled set
-│   ├── toggle-panel.ts               # NEW — opt-in runtime visitor toggle UI
-│   └── enrichment-menu.ts            # MODIFIED — filter menu items by effective enabled set
+│   ├── header-utils.ts               # MODIFIED — filter LozengeSpec[] by effective enabled set; consult columnTypes cache on refresh
+│   ├── toggle-panel.ts               # NEW — opt-in runtime visitor toggle UI; container.isConnected guard; tearDown try/catch wrap
+│   └── enrichment-menu.ts            # MODIFIED — rename EnrichmentType ids (review fix 2A); filter ENRICHMENT_ITEMS by effective enabled set
 ├── utils/
-│   └── enrichment-persistence.ts     # NEW — URL fragment ↔ localStorage for visitor toggle set
+│   └── slider-persistence.ts         # MODIFIED (review fix 1A) — parameterise readFromUrl/writeUrlHash/readFromStorage/writeToStorage by key/suffix; widen PersistedState.entries to string[] | Record<string, number>
 ├── core/__tests__/
 │   ├── enrichment-registry.test.ts   # NEW
 │   ├── page-config.test.ts           # NEW
-│   └── effective-enabled-set.test.ts # NEW
+│   ├── effective-enabled-set.test.ts # NEW
+│   └── column-types-cache.test.ts    # NEW (review fix 4A)
 ├── ui/__tests__/
-│   └── toggle-panel.test.ts          # NEW (Storybook + interaction)
+│   ├── toggle-panel.test.ts          # NEW (Storybook + interaction)
+│   ├── enrichment-menu-filter.test.ts # NEW (review fix 3A — FR-010 acceptance)
+│   └── header-utils.refresh.test.ts  # NEW (review fix 4A — spy on inferHeaderColumnType not invoked on cache hit)
 ├── utils/__tests__/
-│   └── enrichment-persistence.test.ts # NEW
+│   ├── slider-persistence.test.ts    # MODIFIED — exercises generic helpers via slider call sites (no behaviour change)
+│   └── slider-persistence.enrichments.test.ts # NEW — gs.e + string[] entries round-trip
 ├── stories/
 │   └── TogglePanel.stories.ts        # NEW
-└── index.ts                          # MODIFIED — read pageConfig at init; expose pageConfig type
+└── index.ts                          # MODIFIED — read pageConfig at init; expose pageConfig type; call clearColumnTypes on disable()
 
 tests/e2e/
-├── capability-filtering.spec.ts      # NEW — Story 1 + Story 3 (demo subsets)
+├── capability-filtering.spec.ts      # NEW — Story 1 + Story 3 (demo subsets on the five real demos)
 └── capability-filtering-toggle.spec.ts # NEW — Story 2 (live toggle + persistence)
 
 public/demo/
-├── atmosphere.html, ...              # MODIFIED — each existing demo declares an explicit subset
+├── index.html                        # MODIFIED — declares full shipped-enrichment subset
+├── sliders/interpolation.html        # MODIFIED — declares ['heatmap','sliders','statistics']
+├── sliders/alternate-calc-models.html # MODIFIED — declares ['sliders','statistics']
+├── sliders/synced-tables.html        # MODIFIED — declares ['sliders']
+├── sliders/heatmap.html              # MODIFIED — declares ['heatmap','sliders','slider-threshold']
 └── toggle/                           # NEW
     └── live-enrichments.html         # NEW — runtime toggle demo (Story 2 / FR-020)
+
+scripts/
+└── bundle-size.js                    # MODIFIED (review fix 3A / R-11) — re-enable 10 KB gzipped ceiling; exit 1 on overage; --soft flag for warn-only local builds
 ```
 
-**Structure Decision**: Single-project layout, additive. The registry is the single
-new source of truth; the page-config and effective-set resolvers are stateless pure
-functions sized for unit testing. The filter integration into `header-utils.ts` is a
-two-line change inside the existing spec-collection loop, so the existing lozenge
-tests continue to cover the happy path and the new unit tests cover the filter
-semantics in isolation. The toggle panel sits in its own module so it does not bleed
-into pages that don't opt in to it.
+**Structure Decision**: Single-project layout, additive on the new modules and
+**refactor-in-place** for the shared persistence helpers. The registry is the
+single new source of truth; the page-config and effective-set resolvers are
+stateless pure functions sized for unit testing. The filter integration into
+`header-utils.ts` and `enrichment-menu.ts` is a two-line change inside each call
+site's spec-collection loop, so the existing lozenge tests continue to cover
+the happy path and the new unit tests cover the filter semantics in isolation.
+The toggle panel sits in its own module so it does not bleed into pages that
+don't opt in to it. The column-types cache is a tiny WeakMap helper that
+processTable populates once per table and the refresh path consults instead of
+re-walking cell content.
+
+**Notable structural change vs the original plan**: there is no new
+`utils/enrichment-persistence.ts` module. Sharing the existing slider-persistence
+helpers via parameterisation is both DRY (review issue 1) and cheaper on bundle
+budget (R-7 saves ~0.05 KB).
 
 ## Complexity Tracking
 

--- a/specs/012-capability-filtering/plan.md
+++ b/specs/012-capability-filtering/plan.md
@@ -37,33 +37,35 @@ detached from the document; re-enable the 10 KB gzipped ceiling in
 ## Technical Context
 
 **Language/Version**: TypeScript ~5.8 (existing project compiler version; output ES2020+)
+
 **Primary Dependencies**:
-  - Runtime: none new. Existing `simple-statistics`, `shepherd.js` unrelated to this feature.
-  - Build/test: existing Vite 6, Vitest 3, Playwright 1.53, Storybook 9 (unchanged).
-**Storage**: `window.localStorage` (existing per-URL-stem persistence) plus URL fragment
-  params for visitor-set enabled set.
-**Testing**: Vitest unit tests in `src/**/__tests__/`, Storybook 9 interaction tests
-  via `@storybook/addon-vitest`, Playwright e2e under `tests/e2e/`.
-**Target Platform**: Evergreen browsers ≤ 2 years old (Chrome, Firefox, Safari, Edge,
-  Chromium derivatives). Must function from `file://` (offline).
-**Project Type**: Browser library, single project. IIFE bundle (`grid-sight.iife.js`)
-  + npm/ESM via `src/index.ts` entry.
+
+- Runtime: none new. Existing `simple-statistics`, `shepherd.js` unrelated to this feature.
+- Build/test: existing Vite 6, Vitest 3, Playwright 1.53, Storybook 9 (unchanged).
+
+**Storage**: `window.localStorage` (existing per-URL-stem persistence) plus URL fragment params for visitor-set enabled set.
+
+**Testing**: Vitest unit tests in `src/**/__tests__/`, Storybook 9 interaction tests via `@storybook/addon-vitest`, Playwright e2e under `tests/e2e/`.
+
+**Target Platform**: Evergreen browsers ≤ 2 years old (Chrome, Firefox, Safari, Edge, Chromium derivatives). Must function from `file://` (offline).
+
+**Project Type**: Browser library, single project. IIFE bundle (`grid-sight.iife.js`) plus npm/ESM via `src/index.ts` entry.
+
 **Performance Goals**:
-  - Filter check at lozenge-spec build time: O(1) `Set` lookup per candidate spec.
-  - Runtime toggle: lozenge add / remove + cleanup completes within one animation
-    frame (≤ 16 ms) on a mid-range laptop (SC-004).
-  - No re-layout cost beyond the lozenge mutation itself; no full re-process of
-    table data.
+
+- Filter check at lozenge-spec build time: O(1) `Set` lookup per candidate spec.
+- Runtime toggle: lozenge add / remove + cleanup completes within one animation frame (≤ 16 ms) on a mid-range laptop (SC-004).
+- No re-layout cost beyond the lozenge mutation itself; no full re-process of table data.
+
 **Constraints**:
-  - Net bundle delta ≤ 1 KB gzipped for the whole feature (SC-007 + constitution §I).
-  - Runtime toggle panel is opt-in per page but its **code** is part of the bundle;
-    it must be tight enough to fit within the 1 KB total.
-  - No runtime network access (constitution §VI). No new deps.
-  - Keyboard + AT operability for the panel (FR-021 + constitution §III).
-  - Per-URL-stem persistence model unchanged.
-**Scale/Scope**: Same as host-page scope — up to ~10 tables per page, up to ~14
-  registered enrichment ids today (room to grow). Toggle panel lists every
-  registered id; expected list length 10–20 over the next year.
+
+- Net bundle delta ≤ 1 KB gzipped for the whole feature (SC-007 + constitution §I).
+- Runtime toggle panel is opt-in per page but its **code** is part of the bundle; it must be tight enough to fit within the 1 KB total.
+- No runtime network access (constitution §VI). No new deps.
+- Keyboard + AT operability for the panel (FR-021 + constitution §III).
+- Per-URL-stem persistence model unchanged.
+
+**Scale/Scope**: Same as host-page scope — up to ~10 tables per page, up to ~14 registered enrichment ids today (room to grow). Toggle panel lists every registered id; expected list length 10–20 over the next year.
 
 ## Constitution Check
 

--- a/specs/012-capability-filtering/quickstart.md
+++ b/specs/012-capability-filtering/quickstart.md
@@ -1,0 +1,245 @@
+# Quickstart: Configure Which Enrichments Show On Your Page
+
+**Spec**: [./spec.md](./spec.md) · **Plan**: [./plan.md](./plan.md) · **Date**: 2026-05-19
+
+This walks a document author from "I want only heatmap + sliders on this page"
+to a working page in under five minutes. Two paths are shown — declarative
+HTML for the IIFE drop-in, and ESM for build-system consumers — followed by
+the opt-in runtime toggle panel.
+
+---
+
+## Path A — `<script>` drop-in (no build step)
+
+### Step 1 — include the bundle (unchanged)
+
+```html
+<script src="/path/to/grid-sight.iife.js"></script>
+```
+
+### Step 2 — declare the enrichments your page wants
+
+Add a `<script>` block **before** the bundle (or anywhere before
+`gridSight.init()` runs). The order doesn't matter as long as it executes
+first.
+
+```html
+<script>
+  window.gridSight = window.gridSight || {};
+  window.gridSight.pageConfig = {
+    enrichments: ['heatmap', 'sliders', 'statistics'],
+  };
+</script>
+```
+
+That's it. When `init()` runs, the lozenge cluster on every qualifying header
+will show **only** the heatmap, slider, and statistics lozenges. The sort,
+filter, frequency, outlier, sparkline, annotations, units-toggle, cumulative,
+copy-as-csv, and diff-compare lozenges stay absent — no menu items, no DOM,
+no overhead.
+
+### Step 3 — verify
+
+Load the page, click the **GS** master toggle on any table, and confirm the
+lozenge cluster on each header contains exactly the three ids you listed.
+
+### Common variations
+
+**Show everything except one enrichment**: list the rest. The config replaces
+the defaults; there's no subtractive shortcut by design (see FR-005 — the
+intent is that "what's on this page" is immediately readable).
+
+```html
+<script>
+  window.gridSight = { pageConfig: {
+    enrichments: ['heatmap', 'sliders', 'slider-threshold', 'statistics',
+                  'frequency', 'frequency-chart', 'sort', 'filter',
+                  'outlier', 'sparkline', 'annotations', 'units-toggle',
+                  'cumulative', 'copy-as-csv'],
+  } };
+</script>
+```
+
+**Strip every enrichment** (keep just the GS toggle):
+
+```html
+<script>
+  window.gridSight = { pageConfig: { enrichments: [] } };
+</script>
+```
+
+The master GS button still appears; clicking it does nothing visible because
+no enrichment is registered to draw on the headers.
+
+**Forward-compatible reference** to an enrichment your build doesn't have yet:
+
+```html
+<script>
+  window.gridSight = { pageConfig: {
+    enrichments: ['heatmap', 'sliders', 'future-thing-not-shipped-yet'],
+  } };
+</script>
+```
+
+The unknown id is ignored silently — the page works today, and the day the
+new enrichment ships it picks up automatically without an HTML edit.
+
+---
+
+## Path B — npm / ESM consumers
+
+```ts
+import gridSight from '@deepbluec/grid-sight';
+
+gridSight.init({
+  enrichments: ['heatmap', 'sliders', 'statistics'],
+  // …any other existing init options you already pass…
+});
+```
+
+Both fields are optional; omit either and you get the default behaviour for
+that field. If you also set `window.gridSight.pageConfig` in HTML, the values
+you pass to `init()` win on a per-field basis.
+
+---
+
+## Path C — runtime visitor toggle panel (opt-in)
+
+Want a panel where the visitor can flip enrichments on and off live? Two ways
+to opt in:
+
+### C1 — Flag in the page config
+
+```html
+<script>
+  window.gridSight = { pageConfig: {
+    enrichments: ['heatmap', 'sliders', 'sort'],
+    showToggleUi: true,
+  } };
+</script>
+```
+
+The panel mounts top-right of the viewport. Tick / untick a row and the
+lozenges on every table update within one animation frame. Toggling off an
+enrichment that is currently in use (e.g. a heatmap painted on the table) also
+cleans up that live instance — no orphan DOM.
+
+### C2 — Declarative container
+
+If you want to control where the panel renders, put an empty container
+anywhere in your page:
+
+```html
+<aside>
+  <h3>Live toolkit</h3>
+  <div data-gs-toggle-panel></div>
+</aside>
+```
+
+The presence of `[data-gs-toggle-panel]` is itself an opt-in — you don't need
+`showToggleUi: true` if you've placed the container. The panel mounts into
+your container at its natural flow position.
+
+### What the visitor sees
+
+```text
+┌─ Grid-Sight enrichments ─────────────┐
+│ [✓] Heatmap            (heatmap)     │
+│ [✓] Sliders            (sliders)     │
+│ [ ] Threshold slider   (slider-…)    │
+│ [ ] Statistics popup   (statistics)  │
+│ [ ] Frequency table    (frequency)   │
+│ [ ] Sort               (sort)        │
+│ …                                    │
+└──────────────────────────────────────┘
+```
+
+- Every enrichment your build knows is listed (not just the ones currently
+  enabled — the panel is the full menu).
+- Checked rows are the current effective set.
+- The visitor's choices persist for them on this page: the chosen set rides
+  in the URL fragment (`#gs.e=...`) for bookmarking, and falls back to
+  `localStorage` for next-visit-on-this-machine.
+
+---
+
+## What about per-table differences?
+
+The config is **per-page**, not per-table. If two tables on one page need
+different enrichment sets, you have two simple options:
+
+1. Mark the table you want untouched with `data-gs-ignore` (existing
+   attribute). It gets no GS toggle at all.
+2. Split the tables across two pages, each with its own `pageConfig`.
+
+A per-table override (e.g. `data-gs-enrichments` on `<table>`) is intentionally
+out of scope for this feature.
+
+---
+
+## Cheat sheet — known enrichment ids
+
+Copy from this list:
+
+| Id | What it does |
+|---|---|
+| `heatmap` | Colour-codes cells by value |
+| `sliders` | Interpolating row/column sliders |
+| `slider-threshold` | Fade cells below a threshold on a heatmap |
+| `statistics` | Per-column / per-row stats popup (numeric `#`) |
+| `frequency` | Frequency table popup (categorical `#`) |
+| `frequency-chart` | Frequency chart popup (categorical) |
+| `sort` | Click-to-sort lozenge (spec 002 — shipping) |
+| `filter` | Per-column filter (spec 003) |
+| `outlier` | Outlier marker (spec 004) |
+| `sparkline` | Row sparkline (spec 005) |
+| `annotations` | Per-cell annotations (spec 006) |
+| `units-toggle` | Unit conversion toggle (spec 007) |
+| `cumulative` | Running-total column (spec 008) |
+| `copy-as-csv` | Copy table as CSV/TSV/Markdown (spec 009) |
+| `diff-compare` | Diff two rows or two columns (spec 010) |
+
+For an always-current list at runtime:
+
+```js
+console.log(window.gridSight.enrichmentIds);
+```
+
+---
+
+## Troubleshooting
+
+**"I listed `sort` but the lozenge doesn't appear."** Either:
+
+- The sort enrichment hasn't shipped yet (it's spec-only on this branch — the
+  registry knows the id so your config is forward-compatible, but there's no
+  implementation to show), or
+- Your table has no qualifying column for sort. Like every existing
+  enrichment, sort only shows on columns it can act on.
+
+**"I see lozenges I didn't list."** Check that no parent script overwrites
+`window.gridSight.pageConfig` after yours. The library reads it once, at init
+time; the last write before init wins.
+
+**"The toggle panel doesn't appear."** Confirm either:
+
+- `pageConfig.showToggleUi === true`, **or**
+- The page has a `[data-gs-toggle-panel]` element.
+
+Either one opts in. If both are absent, the panel is intentionally suppressed.
+
+**"My visitor's toggle choices stuck across pages."** Each page has its own
+persisted set, keyed by `location.origin + location.pathname`. Two different
+URLs are two different sets. Clear via `localStorage.removeItem(
+'gridsight:<url-stem>:enrichments')` for that page if needed.
+
+---
+
+## What's next
+
+- Read the **full spec** at [`./spec.md`](./spec.md) for the formal
+  requirements, edge cases, and success criteria.
+- See the **plan** at [`./plan.md`](./plan.md) for the implementation
+  structure.
+- See the **runtime-panel demo** at `public/demo/toggle/live-enrichments.html`
+  (added by this feature) for a working example you can copy.

--- a/specs/012-capability-filtering/quickstart.md
+++ b/specs/012-capability-filtering/quickstart.md
@@ -231,7 +231,9 @@ Either one opts in. If both are absent, the panel is intentionally suppressed.
 **"My visitor's toggle choices stuck across pages."** Each page has its own
 persisted set, keyed by `location.origin + location.pathname`. Two different
 URLs are two different sets. Clear via `localStorage.removeItem(
-'gridsight:<url-stem>:enrichments')` for that page if needed.
+'gs:<url-stem>:enrichments')` for that page if needed — the `gs:` prefix is
+shared with the slider persistence, so clearing the whole `gs:` namespace for
+a stem clears every Grid-Sight feature's state for that page at once.
 
 ---
 

--- a/specs/012-capability-filtering/research.md
+++ b/specs/012-capability-filtering/research.md
@@ -40,10 +40,60 @@ adding them now is harmless; adding them now means demos don't need to be edited
 again when those enrichments ship).
 
 **Note on the spec → code naming reconciliation**: The spec FR-003 lists
-`slider` (singular); the code uses `sliders` (plural). The code wins because it's
-the existing surface; we'll note this in the quickstart so authors copy the right
-spelling. The spec is not under SemVer freeze (Development-Phase Posture) so no
-backwards-compat shim is required.
+`slider` (singular); the lozenge code (`src/ui/header-utils.ts`) uses `sliders`
+(plural). The code wins because it's the existing surface; we'll note this in
+the quickstart so authors copy the right spelling. The spec is not under SemVer
+freeze (Development-Phase Posture) so no backwards-compat shim is required.
+
+See **R-1.1** below for the second naming clash uncovered during review — the
+parallel `EnrichmentType` vocabulary in `src/ui/enrichment-menu.ts`.
+
+---
+
+## R-1.1: Reconciling `EnrichmentType` in `src/ui/enrichment-menu.ts` (review fix 2A)
+
+**Decision**: Rename the ids in the `EnrichmentType` union and the matching
+`ENRICHMENT_ITEMS` entries so that there is exactly one identifier vocabulary
+shared by:
+
+- `src/ui/header-utils.ts` `LozengeSpec.id`
+- `src/ui/enrichment-menu.ts` `EnrichmentType`
+- The new `src/core/enrichment-registry.ts`
+
+Mapping:
+
+| Old id (menu)        | New id (registry-aligned) | Notes |
+|----------------------|---------------------------|-------|
+| `slider`             | `sliders`                 | Matches `header-utils.ts` and registry. |
+| `threshold-slider`   | `slider-threshold`        | Matches `data-gs-slider-axis="threshold"` and registry. |
+| `toggle-sliders`     | `sliders` (collapsed)     | Logical duplicate of per-axis `sliders`; one menu predicate covers both axes. |
+| `zscore`             | (removed)                 | No handler in code, no demo, no spec. Treated as dead code; deletion documented. |
+| `aggregate`          | (removed)                 | Same as `zscore`. If revived later, re-add to the registry first. |
+
+Registry ids `heatmap`, `statistics`, `frequency`, `frequency-chart`, `sort`,
+`filter` are already shared with `EnrichmentType` and need no rename.
+
+**Rationale**: Without this rename, the plan's "MODIFIED — filter menu items by
+effective enabled set" step in `src/ui/enrichment-menu.ts` would silently drop
+every slider-family menu item because the registry doesn't recognise `slider` /
+`threshold-slider` / `toggle-sliders`. That breaks FR-010 (disabled enrichments
+absent from menus) in the inverse direction — *enabled* enrichments would also
+disappear. Aligning ids is the only way the single set-membership filter works
+correctly on both call sites.
+
+**Backlog item raised**: `zscore` and `aggregate` are deleted on the assumption
+that they are dead code; the BACKLOG.md entry "investigate `zscore`/`aggregate`
+in `enrichment-menu.ts`" records the call so it can be reversed if either turns
+out to be planned future work.
+
+**Alternatives considered**:
+
+- **Translation layer** (menu-id → registry-id map): rejected — extra layer to
+  maintain, easy to drift, TypeScript can't enforce coverage.
+- **Use menu ids in the registry instead** (rename `sliders` → `slider`): rejected
+  — would also force a rename of the shipped `data-gs-lozenge-id="sliders"` DOM
+  attribute and the `header-utils.ts` `LozengeSpec.id` literal type. More
+  surface area to change for the same end state.
 
 **Alternatives considered**:
 
@@ -134,30 +184,61 @@ lozenge-build path branchless.
 
 ---
 
-## R-4: Persistence of the visitor toggle set
+## R-4: Persistence of the visitor toggle set (revised, review fix 1A)
 
-**Decision**: Reuse the existing per-URL-stem `localStorage` model and the URL
-fragment, with a new fragment key `gs.e` (for **e**nrichments):
+**Decision**: Reuse `src/utils/slider-persistence.ts` literally — not by copying
+its idioms into a new module, but by refactoring its existing helpers to be
+parameterised by the URL fragment key and storage-key suffix, then calling
+them from the enrichment-persistence path. Concretely:
 
-- URL fragment: `#gs.e=heatmap,sliders` (comma-separated ids, alphabetical for
-  stable diff). Parsed alongside the existing `gs.s=` slider key.
-- localStorage fallback: key `gridsight:<url-stem>:enrichments` → JSON string
-  array of ids.
-- On load, URL wins if present; otherwise localStorage; otherwise no visitor
-  override (page config + defaults take over).
-- The toggle panel writes both on every change so that the bookmark and the
-  next-session-on-this-page case both work.
+1. **Refactor `src/utils/slider-persistence.ts`** to expose a small generic
+   layer:
+   - Extract `urlStem()`, `readFromUrl(key, hash?)`, `writeUrlHash(key, entries, hash?)`,
+     `readFromStorage(suffix, stem?)`, `writeToStorage(suffix, payload, stem?)` as
+     reusable building blocks. Existing slider call sites pass `'gs.s'` /
+     `'sliders'` and remain byte-identical in behaviour.
+   - Keep the existing `PersistedState` versioned wrapper
+     (`{ version: 1, entries: ... }`) as the storage payload shape. Sliders
+     use `entries: Record<string, number>`; the enrichments use
+     `entries: string[]` (the id list). Both are valid JSON values of the
+     `entries` field; `isValidPersistedState` widens to accept either.
+2. **Storage key**: `gs:<stem>:enrichments` (NOT `gridsight:...` — the existing
+   slider precedent is `gs:<stem>:sliders`, so the prefix is `gs:`).
+3. **URL fragment key**: `gs.e=heatmap,sliders` (comma-separated ids,
+   alphabetical for stable diff). Parsed alongside the existing `gs.s=` slider
+   key by the same `readFromUrl(key)` helper; values are URL-decoded by the
+   existing path.
+4. **Payload shape on disk**:
+   ```json
+   { "version": 1, "entries": ["heatmap","sliders","statistics"] }
+   ```
+   `version: 1` initially; bumped if the shape ever needs to change. Unrecognised
+   versions cause a fall-back to defaults rather than a throw (mirrors slider
+   precedent).
+5. **Load precedence on init**: URL fragment > localStorage > undefined
+   (page config + defaults then take over). Identical to the slider precedent.
 
-**Rationale**: Sliders, sort (spec 002), and other URL-encoded state already use
-this dual mechanism. Reusing it means one place to read the spec for how
-state outlives a reload, and zero new storage surface.
+**Rationale**: This is the difference between "we use the same model" (the
+original wording, which left two parallel implementations) and "we share the
+helpers" (this revision). The latter satisfies DRY and Principle I (one
+implementation to fit through the bundle budget) and ensures that a future
+fix to the persistence layer fixes both feature surfaces at once.
 
 **Alternatives considered**:
 
-- **Cookie**: rejected — irrelevant for offline / `file://` pages; also leaks to
-  the host page domain unnecessarily.
-- **IndexedDB**: rejected — overkill for a 14-element string list.
+- **Parallel `utils/enrichment-persistence.ts`** that copies the slider idioms:
+  rejected — silently invites divergence (different versioning, different key
+  prefix, different malformed-input policy). Caught by review issue 1.
+- **Cookie**: rejected — irrelevant for offline / `file://` pages; also leaks
+  to the host page domain unnecessarily.
+- **IndexedDB**: rejected — overkill for a 15-element string list.
 - **Per-table persistence**: rejected by the "per-page not per-table" scope.
+
+**Tests added by this revision**: the slider-persistence refactor is covered by
+the existing `src/utils/__tests__/slider-persistence.test.ts` (which moves to
+exercise the generic helpers via the existing call sites). One new unit test
+file `src/utils/__tests__/slider-persistence.enrichments.test.ts` covers the
+`gs.e` + `entries: string[]` round-trip path. No new module file is created.
 
 ---
 
@@ -190,6 +271,16 @@ Host opt-in:
   append to a `<div data-gs-toggle-panel>` if present, else `<body>`.
 - Alternatively: an empty `<div data-gs-toggle-panel></div>` on the page is
   interpreted as opt-in even without the flag (declarative HTML-only opt-in).
+
+**Container resilience (review failure-mode guard)**: before each panel refresh
+(after `onCheckboxChange`), the panel checks `this.root.isConnected`. If the
+host has removed the `[data-gs-toggle-panel]` container (or its descendant
+`[data-gs-toggle-panel-root]`) from the document — a realistic SPA failure
+mode — the panel detaches every listener it owns and stops refreshing. It does
+**not** attempt to remount; the host has explicitly removed the surface, and
+re-attaching could clobber whatever replaced it. A single console warning is
+emitted (`[gridsight] toggle panel container detached; panel disabled until
+next init()`).
 
 **Rationale**: Native form controls are accessible by default and add almost no
 bytes (vs a custom switch widget). Using the same opt-in marker (`data-gs-...`)
@@ -231,6 +322,14 @@ Toggling ON simply rebuilds; no setup hook is needed because the user has to
 click the lozenge to activate the enrichment in the first place — re-enabling
 restores the **availability**, not the prior **activation**.
 
+**Safety wrap (review failure-mode guard)**: every `tearDown(table)` call from
+the runtime refresh path is wrapped in `try { tearDown(table); } catch (e) {
+console.warn('[gridsight] tearDown(' + id + ') threw; continuing', e); }`. A
+buggy tearDown in a third-party-registered enrichment (future use case)
+therefore degrades to a console warning, not a broken page where every
+subsequent toggle stalls. Data-model still mandates "MUST NOT throw" — the
+guard is defence-in-depth, not licence to throw.
+
 **Rationale**: tearDown is the only direction with side effects to clean up.
 Keeping it in the registry colocates each enrichment's "I exist, here's how to
 dismiss me" knowledge, so adding a new enrichment in future is one registry
@@ -248,68 +347,203 @@ edit + one tearDown function.
 
 ---
 
-## R-7: Bundle budget breakdown
+## R-7: Bundle budget breakdown (revised after review)
 
-**Decision**: Target ≤ 0.7 KB gzipped for the whole feature, well under the SC-007
+**Decision**: Target ≤ 0.9 KB gzipped for the whole feature, under the SC-007
 ceiling of 1 KB and within constitution §I's 10 KB total bundle ceiling.
+Estimate revised upward from 0.7 KB after the panel's actual surface area was
+audited during review.
 
 Estimated gzipped contributions:
 
 | Module | Estimate |
 |---|---|
-| `core/enrichment-registry.ts` (data only, 14 entries) | ~0.15 KB |
+| `core/enrichment-registry.ts` (data only, 15 entries) | ~0.15 KB |
 | `core/page-config.ts` (parser + normaliser) | ~0.12 KB |
 | `core/effective-enabled-set.ts` (resolver) | ~0.08 KB |
-| `utils/enrichment-persistence.ts` (URL + localStorage) | ~0.10 KB |
-| `ui/toggle-panel.ts` (DOM + change handler) | ~0.20 KB |
+| `core/column-types-cache.ts` (WeakMap helper, review fix 4A) | ~0.04 KB |
+| Refactor of `utils/slider-persistence.ts` (parameterise key/suffix) + enrichment-specific glue | ~0.05 KB |
+| `ui/toggle-panel.ts` (DOM + change handler + container.isConnected guard + tearDown try/catch) | ~0.40 KB |
 | Filter hooks in `ui/header-utils.ts` + `ui/enrichment-menu.ts` | ~0.05 KB |
-| **Total** | **~0.70 KB** |
+| **Total** | **~0.89 KB** |
 
 **Rationale**: Native checkboxes carry zero bytes (browser-supplied); the
-registry is a single literal; the resolver is one function. Most of the cost is
-the panel's DOM-creation code.
+registry is a single literal; the resolver is one function. The panel revised
+upward from 0.2 → 0.4 KB after counting: fieldset/legend/label scaffolding,
+~15 checkbox rows wired to listeners, the change handler with persistence
+write, the diff between old/new effective set, the per-table refresh loop,
+the container-resilience guard, and the tearDown try/catch wrap. Sharing the
+persistence helpers (review fix 1A) saves ~0.05 KB vs the parallel module
+originally planned.
 
-**Mitigations if budget is exceeded**:
+**Mitigations if measured delta exceeds budget**:
 
 - Compress the registry from object literals to two parallel arrays (ids, labels,
-  defaultOn bitmask).
+  defaultOn bitmask). Buys ~0.05 KB.
 - Inline `effective-enabled-set` into `page-config` (saves one function boundary).
+  Buys ~0.02 KB.
 - Make the panel module lazily-imported in ESM consumers (no gain for IIFE, but
   some for build-system consumers).
+- Inline the column-types-cache into `core/table-processor` if the standalone
+  module's bytes outweigh its testability benefit.
+
+**Measurement**: see R-11 for how the bundle ceiling is enforced at build
+time.
 
 ---
 
-## R-8: Demo subset choices
+## R-10: Column-types cache to keep toggle latency under one frame (review fix 4A)
 
-**Decision**: Each existing demo page declares an explicit `enrichments` list
-that matches the enrichments its narrative exercises, per `specs/011-demo-pages/`.
-The new live-toggle demo declares the full set and opts in to the panel.
+**Decision**: Introduce `src/core/column-types-cache.ts` exporting a
+module-scoped `WeakMap<HTMLTableElement, ColumnType[]>` plus three thin
+helpers:
 
-Initial subsets (the registry-friendly ids in each):
+```ts
+function getColumnTypes(table: HTMLTableElement): ColumnType[];
+function setColumnTypes(table: HTMLTableElement, types: ColumnType[]): void;
+function clearColumnTypes(table: HTMLTableElement): void;
+```
+
+`processTable` (the only function that legitimately changes a table's
+detected column types) calls `setColumnTypes` after running
+`detectColumnTypes`. `injectPlusIcons` on the runtime refresh path calls
+`getColumnTypes` instead of re-running `inferHeaderColumnType` per header.
+`clearColumnTypes(table)` is called from `disable()` so a re-init starts
+fresh.
+
+**Rationale**: Without the cache, every checkbox flip triggers a full
+column-type re-walk of every table on the page (R-6's `injectPlusIcons` path
+ends in `inferHeaderColumnType` which `cleanNumericCell`-walks the body
+cells). On a 10-table page averaging 25 headers, that's ~250 re-walks per
+toggle, plus the same `cleanNumericCell` work the original `processTable`
+already did. With the cache, the refresh path becomes "remove old lozenges,
+re-add filtered lozenges using cached types" — pure DOM work, bounded by the
+number of headers, not by cell count.
+
+A `WeakMap` is correct here because the table element's lifetime is the
+authoritative anchor for cache validity — when the host removes the table
+from the DOM and drops references, the cache entry is collected automatically.
+No manual eviction beyond `disable()` is required.
+
+**Tests added**:
+
+- `src/core/__tests__/column-types-cache.test.ts` — set/get/clear and WeakMap
+  semantics (verify identity behaviour, not GC timing).
+- `src/ui/__tests__/header-utils.refresh.test.ts` — assert that a synthesised
+  refresh path calls `getColumnTypes` (spy) without invoking
+  `inferHeaderColumnType` for already-known tables.
+
+**Alternatives considered**:
+
+- **Cache on the table element itself** (`table._gsColumnTypes`): rejected —
+  mutates host DOM, harder to unit-test, leaks into the DOM contract.
+- **Recompute lazily inside `inferHeaderColumnType`** with an instance check:
+  rejected — keeps the per-header overhead, only saves the cleanNumericCell
+  walk; the simpler full-table cache is both cheaper and more predictable.
+- **Do nothing** (Issue 4C in review): rejected — already measured 250
+  re-walks per toggle on a realistic demo size; SC-004's one-frame budget is
+  not credible without it.
+
+---
+
+## R-11: Bundle-size enforcement — reconcile constitution and existing script
+
+**Discovery**: `scripts/bundle-size.js` (wired into the `yarn build` pipeline
+via `package.json`) was previously hardened to fail builds above 10 KB
+gzipped but is currently **informational only** — its leading comment reads
+"Bundle size is informational only — Grid-Sight typically runs on a LAN or
+locally on a PC, so the bundle ceiling has been relaxed." This is in tension
+with constitution v1.1.0 §I and §Performance & Distribution Constraints,
+both of which still mandate the 10 KB gzipped ceiling and that increases
+above it "MUST be rejected or accompanied by an explicit budget-raise
+amendment to this constitution."
+
+**Decision for this feature's implementation**: re-enable enforcement in
+`scripts/bundle-size.js`. Specifically:
+
+- Replace the "informational only" comment with a one-paragraph
+  justification block citing constitution §I.
+- After computing `gzKB`, compare against a constant `MAX_GZ_KB = 10` and
+  `process.exit(1)` with a clear message if exceeded.
+- Add a `--soft` flag that preserves the existing warn-only behaviour for
+  pre-PR local builds where the author wants the number but not the fail.
+- Do not invent a new script (`scripts/check-bundle-size.mjs` from the
+  review's option 3A wording) — the existing `bundle-size.js` already runs
+  in the right place. Editing it is the minimal diff.
+
+**Open question for /speckit-tasks or implementation**: if the current
+bundle is already above 10 KB at the moment enforcement is re-enabled, the
+correct response is **not** to weaken the threshold silently — it is to
+either land a bundle-cut PR first or amend the constitution with a recorded
+budget-raise. The task that flips enforcement on MUST measure the current
+size and pick one of those two paths before merging.
+
+**Rationale**: 3A in the review explicitly committed to "scripts/check-bundle-size.mjs
+invoked by yarn build, failing >10 KB gzipped." The existing
+`scripts/bundle-size.js` is the path already wired in; re-enabling it
+fulfils the same goal with one fewer file. The "relaxed" comment is itself
+a constitution violation that pre-dates this feature; surfacing it here
+makes the violation resolvable in the same PR cycle rather than letting it
+ossify.
+
+**Alternatives considered**:
+
+- **Add a separate `.mjs` script and leave `bundle-size.js` informational**:
+  rejected — two scripts measuring the same bundle is a DRY violation, and
+  the existing script being informational while a new one fails is just
+  confusing.
+- **Amend the constitution to relax the ceiling**: out of scope for a
+  feature PR; would need a separate constitution amendment PR with the
+  Sync Impact Report bump per constitution Governance.
+- **Track delta-per-feature instead of absolute ceiling**: rejected —
+  constitution speaks in absolutes; per-feature deltas are useful as
+  reviewer aids but not as the gate.
+
+---
+
+## R-8: Demo subset choices (narrowed after review)
+
+**Decision**: Each demo page that **exists today** declares an explicit
+`enrichments` list that matches the enrichments its narrative exercises. The
+new live-toggle demo declares the full set and opts in to the panel. Demo
+pages from spec 011 (`real-world/atmosphere`, `mixed/categorical-and-numeric`,
+`before-after/*`, `retrofit/*`) are **not** in scope for this feature — they
+do not exist yet; their `pageConfig` declarations land in the spec-011
+implementation PR alongside the demo HTML itself.
+
+Initial subsets (the registry-friendly ids in each), covering only the five
+real files today:
 
 | Demo page | Subset |
 |---|---|
+| `public/demo/index.html` | `heatmap`, `sliders`, `slider-threshold`, `statistics`, `frequency`, `frequency-chart` (demo hub — keeps every shipped affordance available) |
 | `public/demo/sliders/interpolation.html` | `heatmap`, `sliders`, `statistics` |
 | `public/demo/sliders/alternate-calc-models.html` | `sliders`, `statistics` |
 | `public/demo/sliders/synced-tables.html` | `sliders` |
 | `public/demo/sliders/heatmap.html` | `heatmap`, `sliders`, `slider-threshold` |
-| `public/demo/real-world/atmosphere.html` (spec 011) | `heatmap`, `sliders`, `statistics` |
-| `public/demo/mixed/categorical-and-numeric.html` (spec 011) | `heatmap`, `sliders`, `statistics`, `sort`, `filter`, `frequency`, `frequency-chart` |
-| `public/demo/before-after/*.html` (spec 011) | full default set (the demo's whole point is "here's what GS adds") |
-| `public/demo/retrofit/*.html` (spec 011) | `heatmap`, `statistics` (minimal, to look unobtrusive) |
 | `public/demo/toggle/live-enrichments.html` (NEW) | full set + `showToggleUi: true` |
 
-**Rationale**: Each subset is the smallest set that still tells the demo's story.
-The exact subsets are recorded here so reviewers can match them against the demo
-acceptance criteria in story 3 of the spec.
+**Rationale**: Each subset is the smallest set that still tells the demo's
+story. Narrowing the list to existing files prevents the implementation task
+from either fabricating placeholder demos or skipping FR-019 silently. The
+spec-011 demos pick up their `pageConfig` declarations in their own PR — the
+registry-and-filter mechanism shipped here works fine for them because
+unknown ids and missing pages have no failure surface.
+
+**FR-019 reading under this scope**: "Every demo page that currently exists"
+literally means the five files in the table above plus the new live-toggle
+demo. The spec-011 demo PR is responsible for adding `pageConfig` to its own
+files when it lands.
 
 **Alternatives considered**:
 
-- **Move every demo to the full default set**: rejected — defeats the purpose of
-  the feature.
+- **Move every demo to the full default set**: rejected — defeats the purpose
+  of the feature.
 - **Leave existing demos un-configured and only configure the new demo**:
-  rejected — fails FR-019 (every demo must declare an explicit set so future
-  enrichments don't auto-appear).
+  rejected — fails FR-019 for the demos that *do* exist.
+- **Configure the spec-011 demos preemptively** (the pre-review wording):
+  rejected — the files don't exist, so the configuration cannot be checked in
+  or tested. Belongs to the spec-011 implementation PR.
 
 ---
 

--- a/specs/012-capability-filtering/research.md
+++ b/specs/012-capability-filtering/research.md
@@ -125,6 +125,7 @@ The two paths share a single normalisation routine in `src/core/page-config.ts`.
 **Rationale**: The IIFE path needs to work with **no** JS knowledge beyond
 copy-pasting a snippet (the project's whole pitch — drop in one script tag, edit
 one HTML file). A `<meta>` tag was tempting for being even more declarative, but:
+
 - it forces a string-encoding for the list, which authors get wrong (commas vs
   spaces vs trailing commas);
 - it can't carry the boolean `showToggleUi` flag without inventing a syntax;
@@ -209,9 +210,11 @@ them from the enrichment-persistence path. Concretely:
    key by the same `readFromUrl(key)` helper; values are URL-decoded by the
    existing path.
 4. **Payload shape on disk**:
+
    ```json
    { "version": 1, "entries": ["heatmap","sliders","statistics"] }
    ```
+
    `version: 1` initially; bumped if the shape ever needs to change. Unrecognised
    versions cause a fall-back to defaults rather than a throw (mirrors slider
    precedent).
@@ -256,6 +259,7 @@ provided, docked top-right of the viewport. Each registered enrichment is one ro
 ```
 
 Construction rules:
+
 - Single `<fieldset>` with a `<legend>` ("Grid-Sight enrichments").
 - One `<label><input type="checkbox"> Label <span class="id">(id)</span></label>`
   per registered id.
@@ -267,6 +271,7 @@ Construction rules:
   fieldset focus order).
 
 Host opt-in:
+
 - `window.gridSight.pageConfig.showToggleUi = true` — auto-create panel and
   append to a `<div data-gs-toggle-panel>` if present, else `<body>`.
 - Alternatively: an empty `<div data-gs-toggle-panel></div>` on the page is

--- a/specs/012-capability-filtering/research.md
+++ b/specs/012-capability-filtering/research.md
@@ -1,0 +1,365 @@
+# Research: Per-Page Enrichment Capability Filtering
+
+**Spec**: [./spec.md](./spec.md) · **Plan**: [./plan.md](./plan.md) · **Date**: 2026-05-19
+
+This document records every decision needed to take the spec from "what" to "how"
+without introducing implementation details into the spec itself. Each entry lists
+the decision, the rationale, and what was considered and rejected.
+
+---
+
+## R-1: Identifier scheme for enrichments
+
+**Decision**: A single flat list of lowercase, hyphen-separated string ids, exactly
+the ids already used by the in-tree `LozengeSpec.id` field in `src/ui/header-utils.ts`,
+plus one id per future-only enrichment from specs 002–010:
+
+| Id | Source | Status today |
+|---|---|---|
+| `heatmap` | existing lozenge | shipped |
+| `sliders` | existing lozenge (axis sliders, table-wide) | shipped (spec 001) |
+| `slider-threshold` | existing API (no lozenge yet) | shipped (spec 001) |
+| `statistics` | existing lozenge | shipped |
+| `frequency` | existing lozenge | shipped |
+| `frequency-chart` | existing lozenge | shipped |
+| `sort` | spec 002 | spec only |
+| `filter` | spec 003 | spec only |
+| `outlier` | spec 004 | spec only |
+| `sparkline` | spec 005 | spec only |
+| `annotations` | spec 006 | spec only |
+| `units-toggle` | spec 007 | spec only |
+| `cumulative` | spec 008 | spec only |
+| `copy-as-csv` | spec 009 | spec only |
+| `diff-compare` | spec 010 | spec only |
+
+**Rationale**: The lozenge code already names these enrichments; reusing those
+names avoids a second vocabulary and lets the filter be a one-line set membership
+check in `header-utils.ts`. Future-only ids are registered now so demo pages can
+list them defensively (FR-007 already guarantees unknown ids are ignored, so
+adding them now is harmless; adding them now means demos don't need to be edited
+again when those enrichments ship).
+
+**Note on the spec → code naming reconciliation**: The spec FR-003 lists
+`slider` (singular); the code uses `sliders` (plural). The code wins because it's
+the existing surface; we'll note this in the quickstart so authors copy the right
+spelling. The spec is not under SemVer freeze (Development-Phase Posture) so no
+backwards-compat shim is required.
+
+**Alternatives considered**:
+
+- **Numeric or symbolic ids** (e.g. an enum): rejected — opaque in page source,
+  forces an extra lookup step for authors.
+- **Namespaced ids** (e.g. `gs.heatmap`, `gs.slider.axis`): rejected — adds noise
+  for no gain; the registry is already scoped to Grid-Sight.
+- **Class-name reuse** (e.g. `gs-lozenge[data-gs-lozenge-id="heatmap"]`):
+  considered but the ids that land in the DOM are derived from the registry
+  anyway; making the registry the canonical source keeps DOM ids stable and
+  testable.
+
+---
+
+## R-2: Where does the page-level config live?
+
+**Decision**: Two equally-supported entry points, read once at `init()` time:
+
+1. **IIFE / no-build path**: A `<script>` block in the page **before** the
+   Grid-Sight bundle sets `window.gridSight.pageConfig = { enrichments: [...],
+   showToggleUi?: boolean }`. The init code reads this immediately after the
+   bundle loads. If the bundle has already loaded, the snippet still works as
+   long as it runs before `window.gridSight.init()`.
+2. **ESM / build-system path**: `gridSight.init({ enrichments: [...],
+   showToggleUi?: boolean })`. The same option names; the same parser.
+
+The two paths share a single normalisation routine in `src/core/page-config.ts`.
+
+**Rationale**: The IIFE path needs to work with **no** JS knowledge beyond
+copy-pasting a snippet (the project's whole pitch — drop in one script tag, edit
+one HTML file). A `<meta>` tag was tempting for being even more declarative, but:
+- it forces a string-encoding for the list, which authors get wrong (commas vs
+  spaces vs trailing commas);
+- it can't carry the boolean `showToggleUi` flag without inventing a syntax;
+- existing GS surface (`window.gridSight.init`, lozenges) is all JS-driven, so
+  authors already know where to look.
+
+The ESM `init()` path mirrors what build-system consumers already do for other
+options, so it costs nothing extra.
+
+**Alternatives considered**:
+
+- **`<meta name="gs-enrichments" content="heatmap,sliders">`**: rejected as
+  primary mechanism (see above); MAY be added later as a thin wrapper if author
+  feedback demands it.
+- **`data-gs-enrichments` on `<body>`**: same rejection reasons.
+- **Per-table override via `data-gs-enrichments` on `<table>`**: explicitly out
+  of scope per the spec's "per-page not per-table" assumption. Authors who need
+  per-table control already have `data-gs-ignore` and the option to split pages.
+- **Reading the config inside each table's processor**: rejected — every table
+  on the page reads the same config, so resolving the effective set once at
+  `init()` and caching it on the registry is simpler and faster.
+
+---
+
+## R-3: How does the effective enabled set get resolved?
+
+**Decision**: A pure function `resolveEnabledSet(visitorOverride, pageConfig,
+registry) → Set<string>` with this precedence:
+
+1. **Visitor toggle persisted state** (from URL fragment or localStorage), if the
+   page opted in to `showToggleUi`. If the persisted state exists, it wins
+   completely — it replaces the page config, not merges with it.
+2. **Page config `enrichments` array**, if present. Replaces defaults entirely
+   (FR-005). An empty array is honoured as "no enrichments" (edge case).
+3. **Library defaults** — the union of `registry.entries.filter(e =>
+   e.defaultOn).map(e => e.id)`. Today all entries are `defaultOn: true` so this
+   matches the pre-feature behaviour exactly (FR-001 + FR-008).
+
+Unknown ids in the input are silently dropped. Case-insensitive matching;
+duplicates collapse. Non-string entries trigger one console warning and the
+input is rejected — falling back to the next precedence tier (FR-022).
+
+**Rationale**: A pure function is trivially unit-testable, has no DOM
+dependencies, and keeps the precedence order **explicit** in one place rather
+than scattered across the lozenge code. Storing the result on a module-scoped
+cache (rebuilt when `init()` or the toggle panel mutates the set) keeps the
+lozenge-build path branchless.
+
+**Alternatives considered**:
+
+- **Merge instead of replace**: rejected by spec FR-005 — too easy to get
+  surprised by "but I disabled sort and it still shows up because defaults
+  include it".
+- **Pre-compute a boolean per id at registry-construction time**: rejected —
+  the visitor can flip ids at runtime, so the set must be re-derived on each
+  toggle anyway. Storing it as a `Set` once per resolve is fine.
+
+---
+
+## R-4: Persistence of the visitor toggle set
+
+**Decision**: Reuse the existing per-URL-stem `localStorage` model and the URL
+fragment, with a new fragment key `gs.e` (for **e**nrichments):
+
+- URL fragment: `#gs.e=heatmap,sliders` (comma-separated ids, alphabetical for
+  stable diff). Parsed alongside the existing `gs.s=` slider key.
+- localStorage fallback: key `gridsight:<url-stem>:enrichments` → JSON string
+  array of ids.
+- On load, URL wins if present; otherwise localStorage; otherwise no visitor
+  override (page config + defaults take over).
+- The toggle panel writes both on every change so that the bookmark and the
+  next-session-on-this-page case both work.
+
+**Rationale**: Sliders, sort (spec 002), and other URL-encoded state already use
+this dual mechanism. Reusing it means one place to read the spec for how
+state outlives a reload, and zero new storage surface.
+
+**Alternatives considered**:
+
+- **Cookie**: rejected — irrelevant for offline / `file://` pages; also leaks to
+  the host page domain unnecessarily.
+- **IndexedDB**: rejected — overkill for a 14-element string list.
+- **Per-table persistence**: rejected by the "per-page not per-table" scope.
+
+---
+
+## R-5: Runtime toggle panel — UI shape
+
+**Decision**: An opt-in panel placed inside a host-supplied container or, if none
+provided, docked top-right of the viewport. Each registered enrichment is one row:
+
+```text
+[✓] Heatmap                (heatmap)
+[✓] Sliders                (sliders)
+[ ] Threshold slider       (slider-threshold)
+[ ] Sort                   (sort)
+...
+```
+
+Construction rules:
+- Single `<fieldset>` with a `<legend>` ("Grid-Sight enrichments").
+- One `<label><input type="checkbox"> Label <span class="id">(id)</span></label>`
+  per registered id.
+- `checked` reflects the current effective enabled set.
+- `change` event → update visitor-persisted set → call internal `refresh()` →
+  every table on the page re-evaluates its lozenges and tears down any
+  newly-disabled enrichment.
+- The panel itself is keyboard-operable for free (native checkboxes + native
+  fieldset focus order).
+
+Host opt-in:
+- `window.gridSight.pageConfig.showToggleUi = true` — auto-create panel and
+  append to a `<div data-gs-toggle-panel>` if present, else `<body>`.
+- Alternatively: an empty `<div data-gs-toggle-panel></div>` on the page is
+  interpreted as opt-in even without the flag (declarative HTML-only opt-in).
+
+**Rationale**: Native form controls are accessible by default and add almost no
+bytes (vs a custom switch widget). Using the same opt-in marker (`data-gs-...`)
+as elsewhere in the project keeps the surface vocabulary consistent. Panel docked
+top-right by default keeps it out of the way of the tables it controls; host
+authors who want a different position pre-place the container themselves.
+
+**Alternatives considered**:
+
+- **Inline panel above each table**: rejected — panel scope is per-page, not
+  per-table; one panel suffices.
+- **Floating button that expands**: rejected — extra interaction, more code,
+  more accessibility surface. The fieldset is already the smallest correct UI.
+- **Auto-show panel on every page**: rejected — most production pages won't
+  want it; opt-in matches FR-013.
+
+---
+
+## R-6: Tearing down a live enrichment when toggled off
+
+**Decision**: Each registry entry MAY declare a `tearDown(table) → void` hook.
+When the effective enabled set transitions an id from "enabled" to "disabled",
+the resolver calls `tearDown(table)` for every registered table.
+
+Tearndown definitions for currently-shipped enrichments:
+
+| Id | tearDown action |
+|---|---|
+| `heatmap` | call existing `removeHeatmap(table)` (no-args removes all) |
+| `sliders` | call existing `removeAllSliders(table)`; this destroys all axis sliders for the table including their persistence entries |
+| `slider-threshold` | iterate `getSliders(table)`, call `.destroy()` on every `kind === "threshold"` slider |
+| `statistics` | dismiss `window._gsStatisticsPopup` if open |
+| `frequency` | dismiss `window._gsFrequencyDialog` if open |
+| `frequency-chart` | dismiss `window._gsFrequencyChartDialog` if open |
+
+After tearDown, the lozenge cluster on every header is rebuilt via the existing
+`injectPlusIcons(table, columnTypes)` path with the new effective set in force.
+Toggling ON simply rebuilds; no setup hook is needed because the user has to
+click the lozenge to activate the enrichment in the first place — re-enabling
+restores the **availability**, not the prior **activation**.
+
+**Rationale**: tearDown is the only direction with side effects to clean up.
+Keeping it in the registry colocates each enrichment's "I exist, here's how to
+dismiss me" knowledge, so adding a new enrichment in future is one registry
+edit + one tearDown function.
+
+**Alternatives considered**:
+
+- **Universal "destroy this enrichment on this table" event** that each
+  enrichment subscribes to: rejected — over-abstracted for 6 hand-counted cases;
+  tearDown functions are trivially traceable in code.
+- **Don't tear down — just hide the lozenge**: rejected — FR-015 specifically
+  requires that the active instance is cleaned up (no orphan DOM, no stuck
+  overlays); a visitor toggling off "sliders" while a slider is on screen
+  needs the slider to disappear, not just its launcher.
+
+---
+
+## R-7: Bundle budget breakdown
+
+**Decision**: Target ≤ 0.7 KB gzipped for the whole feature, well under the SC-007
+ceiling of 1 KB and within constitution §I's 10 KB total bundle ceiling.
+
+Estimated gzipped contributions:
+
+| Module | Estimate |
+|---|---|
+| `core/enrichment-registry.ts` (data only, 14 entries) | ~0.15 KB |
+| `core/page-config.ts` (parser + normaliser) | ~0.12 KB |
+| `core/effective-enabled-set.ts` (resolver) | ~0.08 KB |
+| `utils/enrichment-persistence.ts` (URL + localStorage) | ~0.10 KB |
+| `ui/toggle-panel.ts` (DOM + change handler) | ~0.20 KB |
+| Filter hooks in `ui/header-utils.ts` + `ui/enrichment-menu.ts` | ~0.05 KB |
+| **Total** | **~0.70 KB** |
+
+**Rationale**: Native checkboxes carry zero bytes (browser-supplied); the
+registry is a single literal; the resolver is one function. Most of the cost is
+the panel's DOM-creation code.
+
+**Mitigations if budget is exceeded**:
+
+- Compress the registry from object literals to two parallel arrays (ids, labels,
+  defaultOn bitmask).
+- Inline `effective-enabled-set` into `page-config` (saves one function boundary).
+- Make the panel module lazily-imported in ESM consumers (no gain for IIFE, but
+  some for build-system consumers).
+
+---
+
+## R-8: Demo subset choices
+
+**Decision**: Each existing demo page declares an explicit `enrichments` list
+that matches the enrichments its narrative exercises, per `specs/011-demo-pages/`.
+The new live-toggle demo declares the full set and opts in to the panel.
+
+Initial subsets (the registry-friendly ids in each):
+
+| Demo page | Subset |
+|---|---|
+| `public/demo/sliders/interpolation.html` | `heatmap`, `sliders`, `statistics` |
+| `public/demo/sliders/alternate-calc-models.html` | `sliders`, `statistics` |
+| `public/demo/sliders/synced-tables.html` | `sliders` |
+| `public/demo/sliders/heatmap.html` | `heatmap`, `sliders`, `slider-threshold` |
+| `public/demo/real-world/atmosphere.html` (spec 011) | `heatmap`, `sliders`, `statistics` |
+| `public/demo/mixed/categorical-and-numeric.html` (spec 011) | `heatmap`, `sliders`, `statistics`, `sort`, `filter`, `frequency`, `frequency-chart` |
+| `public/demo/before-after/*.html` (spec 011) | full default set (the demo's whole point is "here's what GS adds") |
+| `public/demo/retrofit/*.html` (spec 011) | `heatmap`, `statistics` (minimal, to look unobtrusive) |
+| `public/demo/toggle/live-enrichments.html` (NEW) | full set + `showToggleUi: true` |
+
+**Rationale**: Each subset is the smallest set that still tells the demo's story.
+The exact subsets are recorded here so reviewers can match them against the demo
+acceptance criteria in story 3 of the spec.
+
+**Alternatives considered**:
+
+- **Move every demo to the full default set**: rejected — defeats the purpose of
+  the feature.
+- **Leave existing demos un-configured and only configure the new demo**:
+  rejected — fails FR-019 (every demo must declare an explicit set so future
+  enrichments don't auto-appear).
+
+---
+
+## R-9: Accessibility specifics for the toggle panel
+
+**Decision**:
+
+- The panel uses one `<fieldset>` with `<legend>` so screen readers announce its
+  scope.
+- Each checkbox is wrapped in a `<label>` element (clickable label text included
+  in the focusable area).
+- Tab order is sequential top-to-bottom, matching the registry's display order
+  (today: heatmap, sliders, slider-threshold, statistics, frequency,
+  frequency-chart, then alphabetised future ids).
+- Space and Enter both toggle the focused checkbox (native browser behaviour).
+- No `aria-live` region is needed: the visible result of toggling (lozenge
+  appears / disappears) is itself an announcement of state for sighted users;
+  for AT users the checkbox itself announces its new state.
+- Focus is preserved on the checkbox after toggle (the panel is not re-rendered
+  whole — only the targeted control's `checked` is updated and the side effect
+  runs on the table side).
+
+**Rationale**: Native form controls satisfy constitution §III's hard minimums
+without custom ARIA. Keeping the panel persistent (not re-rendered on every
+change) avoids focus loss.
+
+**Alternatives considered**:
+
+- **Custom switch role** (`role="switch"` on a button): rejected — same
+  affordance as a checkbox at higher complexity cost, and checkboxes are the
+  semantically correct control for a multi-toggle list.
+- **`aria-live` announcement of "Heatmap enabled / disabled"**: rejected as
+  noisy; AT already announces the checkbox state change.
+
+---
+
+## Open questions resolved during research
+
+- **"Does the registry need to know default-off entries?"** Yes — FR-002 says
+  the default-on/off choice is explicit per entry. Today every entry is
+  `defaultOn: true`, but the registry field exists from day one so future
+  experimental enrichments can ship default-off without a schema change.
+- **"Should the runtime panel honour `data-gs-ignore` tables?"** Yes —
+  `data-gs-ignore` is upstream of every Grid-Sight effect including the panel's
+  refresh loop. Confirmed in FR + Edge Cases.
+- **"What does the panel do for unrecognised ids in the persisted set?"**
+  Drops them silently on read (FR-007 applies to all input sources, including
+  storage that may have been written by a previous build that registered ids
+  this build no longer knows about).
+
+---
+
+**Status**: All NEEDS CLARIFICATION resolved. Phase 0 complete; Phase 1 may proceed.

--- a/specs/012-capability-filtering/spec.md
+++ b/specs/012-capability-filtering/spec.md
@@ -1,0 +1,313 @@
+# Feature Specification: Per-Page Enrichment Capability Filtering
+
+**Feature Branch**: `012-capability-filtering`
+**Created**: 2026-05-19
+**Status**: Draft
+**Input**: User description: "We've created a collection of new specs, to support new features / capabilities. This will result in too many capabilities to show in one table. We need a way of configuring which capabilities are presented on a page. There can be a default set of config booleans in the JS source file. But, when they want to, document authors should be able to create an instance of this config parameter in the source for a page, and configure which 'enrichments' are displayed on a page. In our demo content we can configure the demos to show a particular set of enrichments that are relative to that demo. Plus a demo where the visitor toggles which enrichments are active on that page."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Document author limits the enrichment set for a page (Priority: P1)
+
+A document author embeds Grid-Sight on a page that contains a single lookup table for
+which only sliders, heatmap, and the statistics popup are meaningful. The other
+enrichments (sort, filter, frequency, outlier, sparkline, annotations, units toggle,
+cumulative column, copy-as-CSV, diff/compare) would clutter the lozenge bar without
+adding value. The author writes a small configuration object in the page source that
+names the enrichments they want enabled, and Grid-Sight initialises showing only
+those — every lozenge, menu item, and runtime affordance for the disabled
+enrichments stays absent.
+
+**Why this priority**: This is the central problem. Without a per-page filter, every
+new enrichment shipped by the library grows the lozenge bar on every page that uses
+Grid-Sight, eventually crowding out the affordances each individual page actually
+needs. Solving this unlocks the rest of the roadmap (more enrichments can be added
+without harming existing pages).
+
+**Independent Test**: Take an existing demo page that currently shows all
+enrichments. Add a page-level config naming a subset (e.g. `["heatmap", "slider",
+"statistics"]`). Reload and verify the lozenge bar shows exactly those three
+affordances, no others, on every qualifying table on the page.
+
+**Acceptance Scenarios**:
+
+1. **Given** a page with a Grid-Sight config that enables only `heatmap` and
+   `slider`, **When** Grid-Sight initialises on the page, **Then** only the heatmap
+   and slider lozenges are rendered on table headers; no sort, filter, frequency,
+   stats, outlier, sparkline, annotation, units-toggle, cumulative, copy, or diff
+   lozenges appear.
+2. **Given** the same page with the same config, **When** the user opens any
+   enrichment menu (e.g. the plus-icon menu on a header), **Then** menu items for
+   disabled enrichments are absent (not greyed out — absent).
+3. **Given** a page with **no** Grid-Sight config object, **When** Grid-Sight
+   initialises, **Then** the library's built-in default set of enabled enrichments
+   is used and the page behaves as it did before this feature shipped.
+4. **Given** a page-level config that enables an enrichment the visitor's build does
+   not include (e.g. a removed or renamed enrichment), **When** Grid-Sight
+   initialises, **Then** the unknown name is ignored, the rest of the config is
+   honoured, and no error is shown to the visitor.
+
+---
+
+### User Story 2 - Visitor toggles enrichments at runtime on a demo page (Priority: P2)
+
+A visitor is exploring a Grid-Sight demo intended to showcase the configuration
+mechanism itself. The page renders a panel listing every enrichment the library
+ships, with a checkbox per entry reflecting the current enabled set. As the visitor
+ticks or unticks a box, the corresponding lozenges appear or disappear on the page's
+tables immediately, without a full reload. This lets a viewer feel the effect of the
+config object directly, without editing HTML.
+
+**Why this priority**: Document authors are persuaded by the static config
+mechanism (Story 1), but reviewers, evaluators, and stakeholders persuade themselves
+faster when they can flip a switch and watch the bar change. The runtime toggle is
+also a debugging aid for authors choosing their own subset.
+
+**Independent Test**: Open the dedicated toggle-demo page. Untick "heatmap" in the
+toggle panel and confirm the heatmap lozenge disappears from every table on the
+page, that any active heatmap is removed, and that ticking the box again restores
+the lozenge (no reload). Repeat for two other enrichments to confirm the panel
+controls work for every entry.
+
+**Acceptance Scenarios**:
+
+1. **Given** the toggle-demo page is loaded with all enrichments enabled, **When**
+   the visitor unticks an enrichment in the panel, **Then** that enrichment's
+   lozenge is removed from every qualifying header on the page within one animation
+   frame and any active instance of that enrichment is cleaned up (no orphan DOM,
+   no stuck overlays).
+2. **Given** an enrichment has been toggled off, **When** the visitor ticks it back
+   on, **Then** the lozenge re-appears in the same place with no page reload and
+   the enrichment is operable again.
+3. **Given** the toggle panel reflects the current set, **When** the visitor reloads
+   the page, **Then** the visitor's last-chosen set is restored from the page's
+   per-URL persistence (same model used by sliders / sort).
+
+---
+
+### User Story 3 - Demo pages showcase enrichment subsets relevant to each demo (Priority: P2)
+
+The existing demo pages (`public/demo/...`) each tell a focused story — atmosphere
+lookup, mixed categorical / numeric, before / after, URL-preloaded, retrofit, etc.
+With every enrichment shipped on every demo, the off-topic lozenges distract from
+the point of each page. Each demo declares a config that exposes only the
+enrichments relevant to that demo's narrative; visitors arriving at the atmosphere
+page see slider + heatmap + statistics; visitors arriving at the categorical roster
+see sort + filter + frequency; and so on.
+
+**Why this priority**: The demos are the primary sales surface for the library; an
+uncluttered demo converts better than a cluttered one. This story is what proves the
+feature is "for real" rather than a theoretical knob.
+
+**Independent Test**: Walk each demo page and verify the lozenge bar on each
+qualifying table contains exactly the enrichments named in that page's demo brief
+(documented in `specs/011-demo-pages/plan.md`), with no extras.
+
+**Acceptance Scenarios**:
+
+1. **Given** the atmosphere demo page, **When** Grid-Sight is enabled, **Then** only
+   slider, heatmap, and statistics affordances appear on the density-ratio table.
+2. **Given** the categorical-and-numeric mixed demo, **When** Grid-Sight is enabled,
+   **Then** Table A (numeric) shows slider + heatmap + numeric stats; Table B
+   (categorical) shows sort + filter + frequency; neither table shows the other's
+   enrichments.
+3. **Given** any demo with a configured subset, **When** the page is rebuilt or
+   re-deployed, **Then** no manual editing of the library bundle is required — the
+   subset is declared in the demo page's own source.
+
+---
+
+### Edge Cases
+
+- **Empty config (`enrichments: []`)**: MUST produce a clean Grid-Sight page with the
+  master GS toggle still visible but no enrichment lozenges. The page MUST NOT
+  fall back to defaults — an explicit empty list is an explicit choice.
+- **Config declared after Grid-Sight has already initialised**: The config MUST be
+  consulted at init time only; a config object inserted later in the page lifecycle
+  is out of scope and MUST NOT cause errors if present.
+- **Config naming an enrichment that exists in the library but is incompatible with
+  every table on the page** (e.g. `slider` on a page with only categorical tables):
+  No error; the lozenge simply does not appear because no table qualifies. This is
+  identical to today's "qualification" behaviour and is not a new concern.
+- **Config naming the same enrichment twice or in mixed case**: Duplicates and case
+  variants MUST resolve to the same enrichment and MUST NOT cause duplicate
+  lozenges or errors. Names are case-insensitive in the config.
+- **Runtime toggle panel on a page where the author also declared a static config**:
+  The runtime panel (Story 2) is opt-in per page — it MUST NOT appear on pages that
+  did not request it, even when those pages declare a config object. When both are
+  present on the same demo, runtime changes override the static config for that
+  visitor's session.
+- **Disabling an enrichment that is currently in use** (e.g. visitor turns off
+  "slider" while a slider is bound to a header): The enrichment MUST be cleaned up
+  fully — any DOM it injected, any state it persists, any event listeners it
+  attached — leaving the page indistinguishable from one where the enrichment was
+  never used.
+- **Re-enabling an enrichment that was previously cleaned up**: The lozenge MUST
+  re-appear in its default idle state. Visitor-created instances (e.g. a slider that
+  was bound to a header before the toggle) are NOT restored automatically.
+- **Tables with `data-gs-ignore`**: Continue to be untouched by Grid-Sight
+  regardless of config; the config controls which enrichments are *available*, not
+  whether Grid-Sight runs at all.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Default configuration (library)**
+
+- **FR-001**: Grid-Sight MUST ship a single, canonical default enabled-enrichment
+  set defined in one place in the source. The default set MUST be the list of
+  enrichments the library currently exposes (i.e. everything shipped to date is
+  enabled by default) so that adopting this feature does not regress any existing
+  page.
+- **FR-002**: The default set MUST be a structured collection (one entry per known
+  enrichment) so that adding a new enrichment to the library requires registering
+  it in exactly one place, and the default-on / default-off choice for each new
+  enrichment is explicit.
+- **FR-003**: Each enrichment MUST be referenced by a stable, lower-case, hyphenated
+  identifier (e.g. `heatmap`, `slider`, `slider-threshold`, `sort`, `filter`,
+  `outlier`, `sparkline`, `frequency`, `statistics`, `annotations`, `units-toggle`,
+  `cumulative`, `copy-as-csv`, `diff-compare`). Identifiers MUST be the contract
+  between page-level config and the library.
+
+**Page-level override**
+
+- **FR-004**: A document author MUST be able to declare, in the source of an
+  individual HTML page, which enrichments are enabled for that page. This
+  declaration MUST be readable by Grid-Sight before any lozenge is rendered.
+- **FR-005**: A page-level declaration MUST replace the library default for that
+  page — it MUST NOT merge with the default. (An author who wants "defaults plus
+  one extra" lists the defaults plus one extra explicitly.) This keeps the per-page
+  enabled set immediately obvious from one read of the page source.
+- **FR-006**: A page-level declaration MUST be expressed as a list (or equivalent
+  collection) of the enrichment identifiers from FR-003. The shape MUST be simple
+  enough to write by hand without consulting documentation; it MUST NOT require
+  knowledge of internal library structures.
+- **FR-007**: A page-level declaration MAY include identifiers the running build
+  does not recognise (e.g. forward-compatible references to future enrichments).
+  Unknown identifiers MUST be silently ignored; known identifiers in the same list
+  MUST still be honoured.
+- **FR-008**: When no page-level declaration is present, Grid-Sight MUST use the
+  library default set (FR-001) unchanged.
+
+**Effect on the UI**
+
+- **FR-009**: For any enrichment not in the effective enabled set, Grid-Sight MUST
+  NOT render the enrichment's lozenge on any header.
+- **FR-010**: For any enrichment not in the effective enabled set, Grid-Sight MUST
+  NOT add the enrichment's entry to any menu (e.g. the plus-icon menu). Disabled
+  enrichments MUST be absent, not greyed out.
+- **FR-011**: For any enrichment not in the effective enabled set, any URL-encoded
+  state for that enrichment MUST be ignored on page load (the page MUST NOT
+  spontaneously activate a disabled enrichment because of a bookmarked URL).
+- **FR-012**: Disabling an enrichment via config MUST NOT prevent the master
+  Grid-Sight toggle from appearing or operating; the page MUST still be
+  enrichable in principle, just with a narrower toolkit.
+
+**Runtime visitor toggle (opt-in per page)**
+
+- **FR-013**: A page MUST be able to opt in to a runtime toggle panel that lets the
+  visitor enable or disable each enrichment without a page reload. Opting in MUST
+  be a single, declarative choice in the page source.
+- **FR-014**: The toggle panel MUST list every enrichment known to the running
+  build (not only those enabled by default or by the page config). Each entry MUST
+  show the enrichment's identifier and a short, human-readable label.
+- **FR-015**: Toggling an enrichment off in the panel MUST remove its lozenge from
+  every qualifying header on the page within one animation frame AND clean up any
+  currently active instance of that enrichment (DOM nodes, overlays, persisted
+  state for that visit) without leaving residue.
+- **FR-016**: Toggling an enrichment on in the panel MUST restore its lozenge to
+  every qualifying header within one animation frame.
+- **FR-017**: The visitor's chosen set MUST persist for that visitor on that page
+  using the same per-URL persistence model the rest of Grid-Sight already uses
+  (URL + localStorage fallback). Reloading the page MUST restore the last set.
+- **FR-018**: When both a static page config (FR-004) and the runtime panel
+  (FR-013) are present on the same page, the runtime panel's persisted state MUST
+  take precedence for that visitor; absence of persisted state MUST fall back to
+  the static page config; absence of both MUST fall back to the library defaults.
+
+**Demo content**
+
+- **FR-019**: Every demo page that currently exists MUST declare an explicit
+  page-level enrichment set so that no demo grows new lozenges automatically as
+  future enrichments are added. The chosen subset MUST match the enrichments the
+  demo's narrative exercises.
+- **FR-020**: One demo page MUST exist whose purpose is to demonstrate the runtime
+  toggle panel (Story 2). This demo MUST use a table on which several enrichments
+  qualify, so that the visitor sees lozenges actually appear and disappear as
+  they toggle.
+
+**Accessibility, error handling, observability**
+
+- **FR-021**: The runtime toggle panel MUST be operable by keyboard alone (focus,
+  tab order, space/enter to toggle) and MUST expose each control's state to
+  assistive technology.
+- **FR-022**: Errors in interpreting a page-level config (e.g. wrong shape,
+  non-string entries) MUST NOT prevent Grid-Sight from initialising; the library
+  MUST fall back to the default set and emit a single console warning describing
+  what was wrong.
+
+### Key Entities *(include if feature involves data)*
+
+- **EnrichmentRegistry**: The single in-library record of every enrichment the
+  build ships, keyed by stable identifier. Holds the default-on flag for each
+  entry and the human-readable label used in the runtime toggle panel.
+- **PageEnrichmentConfig**: The author-supplied, page-scoped declaration of which
+  enrichments are enabled for one HTML page. Optional. When absent, the registry
+  defaults apply.
+- **EffectiveEnabledSet**: The resolved set of enrichment identifiers active for a
+  given page-visit, computed from (in order of precedence): the visitor's runtime
+  toggle choices, the page config, the library defaults.
+- **RuntimeTogglePanel**: An opt-in UI surface that lists every registered
+  enrichment and lets the visitor flip each on or off. Its state is the source of
+  the persisted user choice referenced by EffectiveEnabledSet.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A document author can change which enrichments appear on a page in
+  under 60 seconds, editing only that page's source (no rebuild of the library, no
+  change to any other page).
+- **SC-002**: On a page that disables every enrichment except one, the lozenge bar
+  on any qualifying header contains exactly one lozenge — verified by automated
+  end-to-end test on every shipped demo subset.
+- **SC-003**: Adding a new enrichment to the library in the future requires editing
+  the enrichment registry in exactly one place; no demo page picks up the new
+  enrichment unless the demo's own config is also edited.
+- **SC-004**: A visitor on the runtime-toggle demo can see a lozenge appear or
+  disappear within one animation frame of clicking its checkbox, on a mid-range
+  laptop, with no perceptible flicker on other lozenges.
+- **SC-005**: Reloading a page after the visitor has changed the runtime toggles
+  restores the same enabled set with no flash of an unwanted lozenge beyond one
+  animation frame.
+- **SC-006**: No existing demo page that previously displayed an enrichment loses
+  that enrichment after this feature ships (regression guard: existing visible
+  enrichments stay visible because each demo's explicit config lists them).
+- **SC-007**: The library's published bundle size grows by no more than 1 KB
+  gzipped to accommodate the registry + page-config + runtime-toggle code paths
+  (the runtime-toggle panel itself MAY be opt-in to keep pages that don't use it
+  smaller).
+
+## Assumptions
+
+- The list of enrichments referenced by identifier in FR-003 reflects the
+  enrichments currently spec'd (specs 001–010) plus the existing heatmap,
+  statistics, and frequency affordances. Any enrichment added after this spec is
+  drafted will be registered using the same identifier pattern when it ships.
+- "On a page" means per-HTML-document. There is no requirement to vary the enabled
+  set per table within a single page; if two tables on one page need different
+  enrichments, the author either uses `data-gs-ignore` on one or splits them
+  across two pages. Per-table override is out of scope for this feature.
+- The runtime toggle panel is a separate, opt-in surface. Most production pages
+  will not show it; it exists primarily for the dedicated demo and as a
+  debugging aid for authors. Its visual treatment can reuse existing Grid-Sight
+  UI primitives.
+- Persistence reuses the same per-URL model already shared by sliders, sort, and
+  other URL-encoded state — no new storage mechanism is introduced.
+- All operation remains fully offline (constitution §VI). Reading the page config
+  and rendering the toggle panel happen entirely in the browser with no remote
+  calls.
+- Backwards compatibility: pages that exist today and do not declare a config
+  continue to behave exactly as they do today (FR-001 / FR-008 together preserve
+  this).

--- a/specs/012-capability-filtering/tasks.md
+++ b/specs/012-capability-filtering/tasks.md
@@ -1,0 +1,239 @@
+# Tasks: Per-Page Enrichment Capability Filtering
+
+**Input**: Design documents from `/specs/012-capability-filtering/`
+**Prerequisites**: plan.md ✓, spec.md ✓, research.md ✓, data-model.md ✓, contracts/public-api.md ✓, quickstart.md ✓
+
+**Tests**: Required — constitution Principle II (Test Discipline) mandates Vitest unit + Storybook interaction + Playwright e2e for every new code path; merge gate is the green test suite. Tests are not optional for this feature.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+Single project (browser library) — paths from repo root:
+
+- Source: `src/{core,enrichments,ui,utils}/`
+- Tests: `src/{core,enrichments,ui,utils}/__tests__/`
+- Storybook: `src/stories/`
+- E2E: `tests/e2e/`
+- Demos: `public/demo/`
+- Build scripts: `scripts/`
+
+---
+
+## Phase 1: Setup (Bundle-Size Gate)
+
+**Purpose**: Re-establish the constitution-mandated 10 KB gzipped ceiling before any new code lands. This phase is light because the project already has its build/test infrastructure; only the bundle-size gate needs attention (R-11).
+
+- [ ] T001 Run `yarn build` and record the current `dist/grid-sight.iife.js` gzipped size in `specs/012-capability-filtering/baseline-bundle-size.md` (one-liner: date, raw KB, gzipped KB, gap-to-10-KB). Read-only diagnostic; no code change. Resolves R-11's open question — if the baseline already exceeds 10 KB, stop and surface the result before T002 (decision needed: bundle-cut PR first, or constitution amendment).
+- [ ] T002 Re-enable the 10 KB gzipped ceiling in `scripts/bundle-size.js`: replace the "informational only" comment with a constitution §I justification block; after computing `gzKB`, compare against `MAX_GZ_KB = 10` and `process.exit(1)` on overage; add a `--soft` flag that preserves warn-only behaviour for local pre-PR builds. (Depends on T001 having confirmed the baseline is under 10 KB or having raised the amendment.)
+
+**Checkpoint**: Bundle gate is back to enforcing; every subsequent task's PR will be measured against 10 KB at build time.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish the registry, parsers, resolver, shared infrastructure refactors, and id reconciliation that every user story depends on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T003 [P] Create `src/core/enrichment-registry.ts` exporting `EnrichmentId` (string literal union of the 15 ids), `EnrichmentRegistryEntry` (`{ id, label, defaultOn, tearDown? }`), and `ENRICHMENT_REGISTRY` (the frozen array per data-model.md "Initial contents"). Validate ids via `/^[a-z][a-z0-9-]*$/` at module load. Spec-only entries (sort, filter, outlier, sparkline, annotations, units-toggle, cumulative, copy-as-csv, diff-compare) have no `tearDown`.
+- [ ] T004 [P] Create `src/core/__tests__/enrichment-registry.test.ts` covering: id-format validation, uniqueness, label non-empty, frozen-ness (assert `Object.isFrozen`), and presence of every id named in data-model.md.
+- [ ] T005 [P] Create `src/core/page-config.ts` exporting `parsePageConfig(raw: unknown) → { enrichments: Set<string> | undefined, showToggleUi: boolean }`. Implement FR-022 fallback semantics: non-object → warn+reject; `enrichments` non-array → warn+ignore the field; non-string entries → drop with single warn; lowercase+trim normalisation; case-insensitive dedup; `showToggleUi` non-boolean → coerce via `Boolean()` with warn. Emit each warning at most once per call.
+- [ ] T006 [P] Create `src/core/__tests__/page-config.test.ts` covering each FR-022 fallback path (one assertion per misshapen input), case-insensitive normalisation, dedup, empty array vs missing array distinction.
+- [ ] T007 [P] Create `src/core/effective-enabled-set.ts` exporting `resolveEnabledSet(visitorOverride, pageConfig, registry) → Set<string>` implementing the precedence in research R-3 (visitor > page > defaults). All inputs are read-only; output is a fresh `Set` intersected with `knownIds`.
+- [ ] T008 [P] Create `src/core/__tests__/effective-enabled-set.test.ts` covering: each precedence tier in isolation, empty `pageConfig.enrichments` honoured as "no enrichments", unknown ids dropped from each input source, registry-default fallback.
+- [ ] T009 Create `src/core/column-types-cache.ts` (review fix 4A) exporting a module-scoped `WeakMap<HTMLTableElement, ColumnType[]>` and `getColumnTypes(table)`, `setColumnTypes(table, types)`, `clearColumnTypes(table)`. Document the invariant that only `processTable` writes the cache.
+- [ ] T010 [P] Create `src/core/__tests__/column-types-cache.test.ts` covering set/get/clear identity behaviour (do not assert on GC timing).
+- [ ] T011 Refactor `src/utils/slider-persistence.ts` (review fix 1A): parameterise `readFromUrl(key, hash?)`, `writeUrlHash(key, encoded, hash?)`, `readFromStorage(suffix, stem?)`, `writeToStorage(suffix, payload, stem?)`; widen `PersistedState.entries` to `string[] | Record<string, number>`; widen `isValidPersistedState`; keep existing slider call sites byte-identical by passing `'gs.s'` / `'sliders'`. All existing tests in `src/utils/__tests__/slider-persistence.test.ts` and `src/enrichments/__tests__/slider-persistence.integration.test.ts` must still pass with no edits.
+- [ ] T012 Run `yarn test` and confirm the full slider-persistence test surface remains green after T011. No code change; this is the verification gate for the refactor.
+- [ ] T013 Rename `EnrichmentType` ids in `src/ui/enrichment-menu.ts` (review fix 2A): `'slider'` → `'sliders'`, `'threshold-slider'` → `'slider-threshold'`, collapse `'toggle-sliders'` into `'sliders'` (single id, the menu predicate keeps both axes), delete `'zscore'` and `'aggregate'` from the union and `ENRICHMENT_ITEMS`. Update the one matching call site in `src/ui/toggle-injector.ts:122` (`'threshold-slider'` → `'slider-threshold'`). Grep the whole repo for any other reference to the old strings before merging.
+- [ ] T014 Wire pageConfig reading into `src/index.ts` `init(options)`: read `window.gridSight.pageConfig` once, merge `options.enrichments` / `options.showToggleUi` over it (per-field precedence), call `parsePageConfig`, call `resolveEnabledSet`, store the resulting `Set` in a module-scoped variable readable by the UI layer. Expose `window.gridSight.enrichmentIds` (frozen array) and `window.gridSight.isEnrichmentEnabled(id)` per contracts/public-api.md.
+
+**Checkpoint**: Foundation ready. Registry is the single source of truth; page-config and effective-set resolvers are unit-tested; slider-persistence helpers are parameterised and re-green; column-types cache exists; enrichment-menu vocabulary matches the registry; init reads pageConfig.
+
+---
+
+## Phase 3: User Story 1 - Document author limits the enrichment set for a page (Priority: P1) 🎯 MVP
+
+**Goal**: A page that declares `window.gridSight.pageConfig = { enrichments: [...] }` shows only the named enrichments — every lozenge, menu item, and URL-state-driven activation for the disabled enrichments stays absent.
+
+**Independent Test**: Open `public/demo/sliders/interpolation.html`, add `<script>window.gridSight={pageConfig:{enrichments:['heatmap','sliders']}}</script>` before the bundle, reload, click GS on the table; assert the lozenge cluster on every qualifying header contains exactly the heatmap and sliders lozenges, and that opening any menu shows no `statistics` / `frequency` entries.
+
+### Tests for User Story 1
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation.**
+
+- [ ] T015 [P] [US1] Create `src/ui/__tests__/enrichment-menu-filter.test.ts` (review fix 3A) — instantiate `createEnrichmentMenu` against an `EffectiveEnabledSet` containing only `{'heatmap','sliders'}` and assert: no menu item with `data-gs-enrichment-id` outside that set is rendered; the same call with the full set renders every column-appropriate item. Covers FR-010 acceptance.
+- [ ] T016 [P] [US1] Create `tests/e2e/capability-filtering.spec.ts` — Playwright test that loads a fixture page declaring `enrichments: ['heatmap','sliders','statistics']`, enables GS, asserts the lozenge cluster on every header matches the set, and asserts the menu items match too. Covers Story 1 acceptance scenarios 1–4.
+
+### Implementation for User Story 1
+
+- [ ] T017 [P] [US1] Filter `LozengeSpec[]` in `src/ui/header-utils.ts` `addLozengesToHeader`: after building the specs array, drop entries whose `spec.id` is not in the effective enabled set (read via the foundational module from T014). Two-line change inside the existing collection loop.
+- [ ] T018 [P] [US1] Filter `ENRICHMENT_ITEMS` in `src/ui/enrichment-menu.ts` `createEnrichmentMenu`: extend the existing `availableItems` filter (currently column-type + predicate) with a third clause that requires `item.id` to be in the effective enabled set. Single-line change inside the existing `.filter(...)`.
+- [ ] T019 [US1] Suppress URL-encoded slider state for disabled enrichments (FR-011): in the slider attach path (`src/enrichments/slider.ts` and `slider-threshold.ts`), if the relevant enrichment id (`sliders` or `slider-threshold`) is not in the effective enabled set, skip the `resolveInitialPosition` read so a bookmarked `gs.s=` fragment cannot activate a disabled slider on load. Wraps the existing init-time call site only — no change to live add/remove.
+- [ ] T020 [US1] Add `examples/capability-filtering-fixture.html` under `tests/e2e/fixtures/` (or wherever the existing Playwright fixtures live — confirm path during implementation) for T016 to load. Single table with both numeric and categorical columns so several lozenges qualify and the filter has something to filter.
+
+**Checkpoint**: User Story 1 is fully functional. A page with a static `pageConfig` shows the declared subset. URL-encoded slider state for disabled enrichments is ignored. Tests T015 and T016 pass.
+
+---
+
+## Phase 4: User Story 2 - Visitor toggles enrichments at runtime on a demo page (Priority: P2)
+
+**Goal**: An opt-in panel lists every registered enrichment as a checkbox; ticking / unticking updates lozenges across every table on the page within one animation frame and tears down any active instance of a disabled enrichment.
+
+**Independent Test**: Load `public/demo/toggle/live-enrichments.html` (created in T034), open the panel, untick "heatmap" while a heatmap is painted on the page; assert the heatmap colouring is removed and the heatmap lozenge disappears from every header within one animation frame; tick it back; assert the lozenge re-appears but no heatmap re-paints automatically. Reload and assert the persisted set is restored.
+
+### Tests for User Story 2
+
+- [ ] T021 [P] [US2] Create `src/utils/__tests__/slider-persistence.enrichments.test.ts` — exercise the refactored helpers from T011 with `key='gs.e'` / `suffix='enrichments'` / `entries: string[]`: round-trip `['heatmap','sliders']` through `writeUrlHash` ↔ `readFromUrl` and `writeToStorage` ↔ `readFromStorage`; assert versioned wrapper is written; assert version mismatch falls back to empty.
+- [ ] T022 [P] [US2] Create `src/ui/__tests__/toggle-panel.test.ts` — Vitest interaction test that mounts the panel into a JSDOM document, asserts one row per registered id, simulates `change` events, and asserts the corresponding visitor-persisted set mutates (read via T021's helpers).
+- [ ] T023 [P] [US2] Create `src/stories/TogglePanel.stories.ts` — Storybook story rendering the panel with a fixture table; include an `addon-vitest` interaction test that fires a checkbox change and asserts a lozenge appears / disappears on the fixture table within one frame (`await waitFor`, no fixed timeout).
+- [ ] T024 [P] [US2] Create `src/ui/__tests__/header-utils.refresh.test.ts` (review fix 4A) — synthesise a refresh path that calls `injectPlusIcons` with a pre-populated column-types cache; spy on `inferHeaderColumnType` (the existing internal) and assert it is NOT called on the cached path. Also assert that `clearColumnTypes(table)` followed by a refresh DOES call it again.
+- [ ] T025 [P] [US2] Create `tests/e2e/capability-filtering-toggle.spec.ts` — Playwright test against `public/demo/toggle/live-enrichments.html` (created in T034) covering Story 2 acceptance scenarios 1–3: live toggle off removes lozenges + cleans up active instances; live toggle on restores lozenges; reload restores the persisted set with no flash beyond one animation frame.
+
+### Implementation for User Story 2
+
+- [ ] T026 [US2] Create `src/ui/toggle-panel.ts` exporting `mountTogglePanel(container?)` per data-model.md "RuntimeTogglePanel". Native `<fieldset>` + `<legend>` + one `<label><input type="checkbox"> Label <span class="gs-id-hint">(id)</span></label>` per registered id, in registry display order. Wire `change` events to `onCheckboxChange(id, checked)`. Resolve the container in the order: explicit argument → `[data-gs-toggle-panel]` → `<body>` (dock top-right CSS).
+- [ ] T027 [US2] Implement `onCheckboxChange` in `src/ui/toggle-panel.ts`: write the new visitor-persisted set via the refactored persistence helpers (`writeUrlHash('gs.e', …)` + `writeToStorage('enrichments', …)`); re-derive the effective set via `resolveEnabledSet`; diff old vs new; for each id that transitioned ON → OFF, iterate `tableRegistry` (from `src/index.ts`) and call the registry entry's `tearDown(table)` if present; rebuild lozenges via `injectPlusIcons(table, getColumnTypes(table))` for every registered table. Wrap each `tearDown(table)` call in `try { … } catch (e) { console.warn('[gridsight] tearDown(' + id + ') threw; continuing', e); }` (research R-6 safety wrap).
+- [ ] T028 [US2] Add container-resilience guard to `src/ui/toggle-panel.ts`: at the top of `onCheckboxChange`, check `this.root.isConnected`; if false, detach every event listener the panel owns, emit `console.warn('[gridsight] toggle panel container detached; panel disabled until next init()')` exactly once, and return early without further work (research R-5 addition).
+- [ ] T029 [US2] Wire `processTable` in `src/core/table-processor.ts` (or wherever column types are detected today) to call `setColumnTypes(table, types)` after `detectColumnTypes`. Call `clearColumnTypes(table)` from `gridSight.disable()` in `src/index.ts` so re-init starts fresh.
+- [ ] T030 [US2] Wire `injectPlusIcons` in `src/ui/header-utils.ts` to consult `getColumnTypes(table)` when called from the toggle-panel refresh path (T027), falling back to recomputation if the cache is empty (i.e. first call before `processTable` has cached). The initial-injection call site keeps recomputation; only the refresh path skips it.
+- [ ] T031 [US2] Wire panel opt-in into `src/index.ts` `init()`: after T014 resolves the effective set, if `showToggleUi === true` OR a `[data-gs-toggle-panel]` element exists in the document, call `mountTogglePanel()`. Read the visitor-persisted set on init via the refactored persistence helpers and feed it into `resolveEnabledSet` before mounting (so the panel's initial checkbox states match the visitor's last choices).
+
+**Checkpoint**: User Story 2 is fully functional. The panel renders, toggles cleanly, persists, and tears down active enrichments on disable. All Story 2 tests pass.
+
+---
+
+## Phase 5: User Story 3 - Demo pages showcase enrichment subsets relevant to each demo (Priority: P2)
+
+**Goal**: Every demo page that exists today declares an explicit `pageConfig`, matching research R-8's narrowed table. One new demo showcases the runtime panel.
+
+**Independent Test**: Walk each of the five existing demos and the new toggle demo; assert the lozenge cluster on the qualifying tables matches the declared subset for that page exactly — no extras.
+
+### Implementation for User Story 3
+
+- [ ] T032 [US3] Add `<script>window.gridSight={pageConfig:{enrichments:['heatmap','sliders','slider-threshold','statistics','frequency','frequency-chart']}}</script>` to `public/demo/index.html` (before the bundle `<script>`). Demo hub keeps every shipped affordance available.
+- [ ] T033 [P] [US3] Add `pageConfig: { enrichments: ['heatmap','sliders','statistics'] }` to `public/demo/sliders/interpolation.html`.
+- [ ] T034 [P] [US3] Add `pageConfig: { enrichments: ['sliders','statistics'] }` to `public/demo/sliders/alternate-calc-models.html`.
+- [ ] T035 [P] [US3] Add `pageConfig: { enrichments: ['sliders'] }` to `public/demo/sliders/synced-tables.html`.
+- [ ] T036 [P] [US3] Add `pageConfig: { enrichments: ['heatmap','sliders','slider-threshold'] }` to `public/demo/sliders/heatmap.html`.
+- [ ] T037 [US3] Create `public/demo/toggle/live-enrichments.html` — a single table with both numeric and categorical columns so several enrichments qualify, declaring `pageConfig: { enrichments: [<every registered id>], showToggleUi: true }`. Add a short `<header>` explaining the demo and a link back to the demo home, matching the existing demo navigation style.
+- [ ] T038 [US3] Extend `tests/e2e/capability-filtering.spec.ts` (from T016) with one Playwright assertion per demo: for each of the five existing demos plus the new toggle demo, load the page and assert the lozenge cluster on the qualifying tables matches the declared subset. Covers Story 3 acceptance scenarios 1–3 and FR-019.
+
+**Checkpoint**: User Story 3 is fully functional. Every demo declares an explicit subset; no demo grows new lozenges automatically as future enrichments register.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Tie-down work — documentation walkthrough, bundle verification, full-suite re-run, backlog follow-through.
+
+- [ ] T039 [P] Walk `specs/012-capability-filtering/quickstart.md` end-to-end on the running build: copy each snippet into a fresh page, verify the behaviour matches the prose, fix any drift in the doc. Especially exercise the "Troubleshooting" section's localStorage key reference.
+- [ ] T040 [P] Investigate `zscore` and `aggregate` removal (BACKLOG entry follow-through; T013 deleted them on the assumption they were dead code). Grep the whole repo once more after merge; if either has any reference outside this PR's diff, file the BACKLOG entry as resolved with a link; otherwise leave the BACKLOG entry as-is for the next maintainer.
+- [ ] T041 Run `yarn build` and confirm `dist/grid-sight.iife.js` gzipped size remains ≤ 10 KB. Compare against the T001 baseline; if the delta is above 1 KB, surface in PR description before merging (SC-007 budget reality check).
+- [ ] T042 Run the full test suite (`yarn test` + `yarn test:storybook` + `yarn test:e2e`) and confirm green. Constitution Principle II merge gate.
+- [ ] T043 Update `CLAUDE.md` plan reference only if it has drifted; today it already points at `specs/012-capability-filtering/plan.md`. Confirm at the end of implementation.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately. T001 → T002 sequential.
+- **Foundational (Phase 2)**: Depends on Setup completion. T003–T010 mostly parallel (different files); T011 → T012 sequential (refactor then verify); T013 and T014 sequential after T011 (init wiring uses the refactored helpers).
+- **User Stories (Phase 3+)**: All depend on Foundational completion.
+  - US1 (P1) is the MVP; US2 and US3 may proceed in parallel by different developers after US1's foundational dependencies are in place.
+  - US3's e2e assertions (T038) depend on the demo files being in place (T032–T037) AND the static-config filter (US1) being functional.
+- **Polish (Phase 6)**: Depends on US1 + US2 + US3 being complete (or the subset shipping in the MVP cut).
+
+### Within Each User Story
+
+- Tests are written before implementation (Principle II: tests must FAIL first, then pass).
+- US1: T015/T016 (tests) → T017/T018 (implementation, parallel) → T019 → T020.
+- US2: T021–T025 (tests) → T026 → T027/T028 (sequential — both edit the same file) → T029 → T030 → T031.
+- US3: T032 → T033–T036 (parallel) → T037 → T038.
+
+### Parallel Opportunities
+
+- Foundational T003+T004, T005+T006, T007+T008, T009+T010 are four independent file pairs and can run in parallel.
+- US1 T015+T016 (test files) parallel; T017+T018 (different files) parallel.
+- US2 T021+T022+T023+T024+T025 (five test files) parallel.
+- US3 T033+T034+T035+T036 (four independent demo HTML files) parallel.
+- US2 and US3 can be staffed in parallel after US1 lands.
+
+---
+
+## Parallel Example: User Story 2 test stack
+
+```bash
+# Launch all US2 test files together (different files, no dependencies between them):
+Task: "Create src/utils/__tests__/slider-persistence.enrichments.test.ts"
+Task: "Create src/ui/__tests__/toggle-panel.test.ts"
+Task: "Create src/stories/TogglePanel.stories.ts"
+Task: "Create src/ui/__tests__/header-utils.refresh.test.ts"
+Task: "Create tests/e2e/capability-filtering-toggle.spec.ts"
+```
+
+## Parallel Example: User Story 3 demo updates
+
+```bash
+# Launch the four sliders demo updates together (different files, no shared state):
+Task: "Add pageConfig to public/demo/sliders/interpolation.html"
+Task: "Add pageConfig to public/demo/sliders/alternate-calc-models.html"
+Task: "Add pageConfig to public/demo/sliders/synced-tables.html"
+Task: "Add pageConfig to public/demo/sliders/heatmap.html"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. Complete Phase 1: Setup (T001 → T002).
+2. Complete Phase 2: Foundational (T003–T014).
+3. Complete Phase 3: User Story 1 (T015–T020).
+4. **STOP and VALIDATE**: Open a fresh page, declare a subset, confirm only the named lozenges appear. Run T015 + T016. This is a shippable increment — pages that don't want the toggle panel get the value of the filter immediately.
+
+### Incremental Delivery
+
+1. Setup + Foundational → bundle gate restored, registry + resolver landed. **(merge-able)**
+2. + User Story 1 → static config works. **(MVP — merge-able)**
+3. + User Story 3 → existing demos visibly cleaner. **(merge-able)**
+4. + User Story 2 → live toggle demo. **(complete feature)**
+5. + Polish.
+
+Note: US3 can ship after US1 alone; US2 is independent of US3 and may ship in either order after US1.
+
+### Parallel Team Strategy
+
+With multiple developers:
+
+1. One developer completes Setup + Foundational (Phase 1 + 2). Hands off when the registry, resolver, refactor, and init wiring are merged.
+2. Once Foundational is done:
+   - Developer A: User Story 1 (filter integration, tests, slider URL-state suppression).
+   - Developer B: User Story 2 (toggle panel, persistence, refresh path, cache wiring).
+   - Developer C: User Story 3 (demo updates, e2e assertions).
+3. Polish phase is done by whoever finishes their story first; trivial to parallelise.
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies on incomplete tasks.
+- [Story] label maps task to specific user story for traceability.
+- Each user story is independently completable and testable — US1 ships without US2 or US3; US3 needs US1 only for the e2e demo assertions to be meaningful.
+- Verify tests fail before implementing them.
+- Commit after each task or logical group; the existing branch (`claude/add-capability-filtering-dTXwp`) already carries the spec + plan commits.
+- Stop at any checkpoint to validate independently.
+- Avoid: vague tasks, same-file conflicts, cross-story dependencies that break independence.
+- Constitution gates at merge time: `yarn test` green, `yarn test:e2e` green, `yarn build` green with bundle ≤ 10 KB gzipped (T002 enforces).
+- Open question from R-11 (recorded in plan post-review re-check): if T001 measures the current bundle above 10 KB, **stop** and surface the result — flipping enforcement on a violating bundle would break the build immediately. Either bundle-cut to <10 KB first or land a constitution amendment with a recorded budget-raise. Do not weaken the threshold silently.

--- a/specs/012-capability-filtering/tasks.md
+++ b/specs/012-capability-filtering/tasks.md
@@ -206,10 +206,10 @@ Task: "Add pageConfig to public/demo/sliders/heatmap.html"
 ### Incremental Delivery
 
 1. Setup + Foundational → bundle gate restored, registry + resolver landed. **(merge-able)**
-2. + User Story 1 → static config works. **(MVP — merge-able)**
-3. + User Story 3 → existing demos visibly cleaner. **(merge-able)**
-4. + User Story 2 → live toggle demo. **(complete feature)**
-5. + Polish.
+2. Add User Story 1 → static config works. **(MVP — merge-able)**
+3. Add User Story 3 → existing demos visibly cleaner. **(merge-able)**
+4. Add User Story 2 → live toggle demo. **(complete feature)**
+5. Add Polish.
 
 Note: US3 can ship after US1 alone; US2 is independent of US3 and may ship in either order after US1.
 


### PR DESCRIPTION
Adds spec for per-page enrichment capability filtering: a library default
set, optional page-level override, and an opt-in runtime visitor toggle
panel. Demo pages will declare explicit subsets so the lozenge bar stays
focused as more enrichments ship.

https://claude.ai/code/session_01LMBVSWsQyCYD17om5oYbBX