### PR TITLE
docs: add complete specification for row visibility & order (sort + filter)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/001-dynamic-sliders"
+  "feature_directory": "specs/002-003-row-visibility"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-[specs/001-dynamic-sliders/plan.md](specs/001-dynamic-sliders/plan.md)
+[specs/002-003-row-visibility/plan.md](specs/002-003-row-visibility/plan.md)
 <!-- SPECKIT END -->

--- a/specs/002-003-row-visibility/checklists/requirements.md
+++ b/specs/002-003-row-visibility/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Row Visibility & Order (Sort + Filter)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-19
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [ ] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [ ] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [ ] No implementation details leak into specification
+
+## Notes
+
+- **Implementation-detail items intentionally not auto-fixed.** The spec references internal module paths (`utils/visible-rows.ts`, `src/utils/slider-persistence.ts`, `ui/header-utils.ts`), platform APIs (`Array.prototype.sort`, `Intl.Collator`), and browser primitives (`localStorage`, URL fragment) as part of a deliberate **contract style** carried forward from the source specs `002-sort` and `003-filter`. These references are the project's established convention for naming the shared surface that downstream features bind to. Rewriting them away would break consistency with the rest of `specs/` and remove information the downstream specs (`005-sparkline`, `008-cumulative-column`, `009-copy-as-csv`, `010-diff-compare`) explicitly depend on. Flagged for awareness; recommend keeping as-is for this project.
+- **Acceptance scenarios for US1–U4 and US6 are by reference** to `002-sort/spec.md` and `003-filter/spec.md`. This is correct given the spec's "Supersedes (planning only, not history)" stance, but readers must have those source specs available. US5 (the new combination story) has full inline scenarios.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan` — in this case, both incomplete items are the same finding (implementation-detail references), treated as accepted project convention. No blockers for `/speckit-plan`.

--- a/specs/002-003-row-visibility/contracts/url-fragment-schema.md
+++ b/specs/002-003-row-visibility/contracts/url-fragment-schema.md
@@ -1,0 +1,139 @@
+# Contract: Combined sort + filter URL-fragment schema (`gs.v`)
+
+**Spec**: [../spec.md](../spec.md) · **Plan**: [../plan.md](../plan.md) · **Research**: [../research.md](../research.md) §R-4 · **Date**: 2026-05-19
+
+This document fixes the URL serialisation that satisfies **FR-VP-006**
+(single per-page namespace), **FR-VP-007** (filters applied before sort
+on load), and **SC-004** (100% reproducibility across machines without
+`localStorage`).
+
+The codec lives in `src/utils/view-state-url.ts`. It is **separate** from
+the slider codec in `src/utils/slider-persistence.ts` (`gs.s`) — the two
+co-exist in `location.hash`, keyed independently. Per-URL-stem scope
+(origin + pathname) is inherited from the slider codec's behaviour but
+expressed only in the surrounding load/save glue; the codec itself is
+pure.
+
+---
+
+## Fragment parameter
+
+```text
+gs.v=<table-directive>(,<table-directive>)*
+```
+
+Sits inside `location.hash` as one `&`-separated parameter. Other
+parameters (notably `gs.s` for sliders) are preserved on every read /
+write.
+
+---
+
+## Table directive grammar
+
+```text
+table-directive    := <table-id> "(" <body> ")"
+body               := <filter-clause>* <sort-clause>?
+filter-clause      := "f:" <col-key> ":" <predicate-body> ";"
+sort-clause        := "s:" <col-key> ":" <direction>
+direction          := "asc" | "desc"
+col-key            := slug(header-text) | "c" <columnIndex>
+predicate-body     := <numeric-range> | <categorical-list>
+numeric-range      := "n:" [ <number> ] ":" [ <number> ] [ ":h" ]
+                      ; first number = min, second = max; trailing ":h" sets hideEmpty
+                      ; either bound may be empty (open-ended)
+categorical-list   := "v:" <value> ( "|" <value> )* [ ":h" ]
+value              := URL-encoded UTF-8 string (percent-encoding); empty string allowed
+```
+
+**Ordering inside the body matters**: filters always precede the sort
+clause. The parser MUST apply filters before sort on load (FR-VP-007).
+Encoders MUST emit filters first.
+
+---
+
+## Worked examples
+
+| State | URL fragment value |
+|-------|--------------------|
+| Sort `Amount` descending, no filters, table id `tbl-orders` | `gs.v=tbl-orders(s:amount:desc)` |
+| Numeric range `100–500` on `Amount`, no sort | `gs.v=tbl-orders(f:amount:n:100:500;)` |
+| Numeric range `100–∞`, hide empties, sorted desc | `gs.v=tbl-orders(f:amount:n:100::h;s:amount:desc)` |
+| Categorical filter `Region ∈ {EU, US}`, sorted `Date` asc | `gs.v=tbl-orders(f:region:v:EU%7CUS;s:date:asc)` |
+| Two tables on one page | `gs.v=t1(s:name:asc),t2(f:status:v:open;)` |
+
+---
+
+## Column-key derivation
+
+Implemented in `view-state-url.ts`:
+
+```ts
+function colKey(header: HTMLTableCellElement, columnIndex: number): string {
+  const text = (header.textContent ?? '').trim().toLowerCase();
+  const slug = text.replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  return slug || `c${columnIndex}`;
+}
+```
+
+- Stable across reloads while header text is unchanged.
+- Collision (two columns slug to the same key) → second occurrence falls
+  back to `c<columnIndex>`; the codec disambiguates on encode by
+  preferring the leftmost match on decode.
+- Headers changing text after persistence → the directive is silently
+  dropped on load (matches the "missing column → silently dropped"
+  rule).
+
+---
+
+## Parse / encode semantics
+
+- **Round-trip**: `parse(encode(state)) === state` for every valid
+  state. Covered by `view-state-url.test.ts`.
+- **Lenient decode**: any unparseable directive is dropped, NOT thrown.
+  The rest of the URL still applies.
+- **Empty state never written**: when a table has neither sort nor
+  filters, its directive is omitted from `gs.v`. When `gs.v` itself is
+  empty, the parameter is removed from the fragment (matches
+  `slider-persistence.ts` behaviour).
+- **Order of tables**: encoders list table directives in DOM order.
+  Decoders do not depend on order.
+- **Character budget**: keep directives compact — typical URLs in the
+  demo pages target < 200 characters of `gs.v` payload. No hard limit.
+- **No base64, no JSON.stringify**: the grammar above is the canonical
+  form. Choosing a tiny custom grammar over JSON saves ~30% of bytes
+  and avoids the special-character escaping that JSON requires inside
+  a fragment.
+
+---
+
+## Restore-on-load sequence
+
+In `src/index.ts` `init()`, *before* the lozenge cluster mounts:
+
+```text
+1. parse location.hash → { tables: [{ id, sort, filters[] }] }
+2. for each parsed entry whose table exists on the page:
+     a. apply each filter predicate via setFilter(table, colIdx, pred)
+        (filter-then-sort order per FR-VP-007)
+     b. apply sort via setSort(table, sortDirective) if present
+3. proceed with normal processTable() / injectPlusIcons() so the lozenges
+   mount already reflecting the restored state.
+```
+
+This satisfies **SC-003** (no flash beyond one animation frame) because
+the pipeline computes synchronously and the first paint already
+includes the projection.
+
+---
+
+## Interaction with `gs.s`
+
+`gs.s` (sliders, owned by spec 001) and `gs.v` (this contract) are
+**peer parameters** under `location.hash`. The slider codec preserves
+unknown parameters on write, and so does the view-state codec. Edits
+to one parameter MUST NOT clobber the other.
+
+A small shared helper in `view-state-url.ts` reads/writes individual
+named fragment parameters by delegating to the same parsing approach
+already used by `slider-persistence.ts` (`writeUrlHash`-style preserve-
+others), but as a separate function (no behavioural coupling).

--- a/specs/002-003-row-visibility/contracts/visible-rows-api.md
+++ b/specs/002-003-row-visibility/contracts/visible-rows-api.md
@@ -1,0 +1,134 @@
+# Contract: `utils/visible-rows.ts` public surface
+
+**Spec**: [../spec.md](../spec.md) · **Plan**: [../plan.md](../plan.md) · **Data model**: [../data-model.md](../data-model.md) · **Date**: 2026-05-19
+
+This is the **only** sanctioned read-channel for row order and row
+visibility (FR-VP-002). Every downstream feature (`005-sparkline`,
+`008-cumulative-column`, `009-copy-as-csv`, `010-diff-compare`) consumes
+this contract; nothing else reads `tbody.rows` directly.
+
+Stable for spec v1 under the Development-Phase Posture — MAY change
+before production, but only by a PR that updates this file and every
+downstream consumer in the same commit.
+
+---
+
+## Exports
+
+```ts
+// From src/utils/visible-rows.ts
+
+export interface VisibleRowEntry {
+  readonly row: HTMLTableRowElement;
+  readonly dimmed: boolean;
+  readonly sourceIndex: number;
+}
+
+export interface SortDirective {
+  readonly columnIndex: number;
+  readonly columnKey: string;
+  readonly direction: 'asc' | 'desc';
+}
+
+export interface FilterPredicate {
+  readonly columnIndex: number;
+  readonly columnKey: string;
+  test(row: HTMLTableRowElement): boolean;
+  toDirective(): FilterDirective;
+}
+
+export type FilterDirective =
+  | { readonly kind: 'numeric-range'; readonly columnKey: string; readonly min: number | null; readonly max: number | null; readonly hideEmpty: boolean }
+  | { readonly kind: 'categorical'; readonly columnKey: string; readonly allowed: readonly string[]; readonly hideEmpty: boolean };
+
+export interface VisibleRowSequence {
+  readonly entries: readonly VisibleRowEntry[];
+  readonly sort: SortDirective | null;
+  readonly filters: ReadonlyMap<number, FilterPredicate>;
+  readonly revision: number;
+}
+
+/** Read the current Visible Row Sequence for a table. Idempotent / cheap. */
+export function getVisibleRows(table: HTMLTableElement): VisibleRowSequence;
+
+/** Subscribe to pipeline changes. Listener fires synchronously after every re-evaluation. */
+export function onVisibleRowsChange(
+  table: HTMLTableElement,
+  listener: (seq: VisibleRowSequence) => void
+): () => void;
+
+/** Apply a sort directive. Pass `null` to clear sort. */
+export function setSort(table: HTMLTableElement, directive: SortDirective | null): void;
+
+/** Apply, update, or remove a filter predicate. */
+export function setFilter(table: HTMLTableElement, columnIndex: number, predicate: FilterPredicate | null): void;
+
+/** Clear every active filter on a table. Sort is untouched. */
+export function clearFilters(table: HTMLTableElement): void;
+
+/** Restore byte-identical DOM and forget per-table state (idempotent). */
+export function teardown(table: HTMLTableElement): void;
+```
+
+---
+
+## Behaviour guarantees
+
+1. **`getVisibleRows` is synchronous and cheap**. It returns the cached
+   `VisibleRowSequence` from the most recent re-evaluation — no
+   recomputation, no DOM walk.
+
+2. **`onVisibleRowsChange` fires synchronously** after every successful
+   `setSort` / `setFilter` / `clearFilters` / URL-restore call, before
+   control returns to the caller. The listener receives the same
+   `VisibleRowSequence` instance that the next `getVisibleRows` call
+   will return.
+
+3. **`setSort(table, null)` is a no-op if sort is already idle**. Same
+   for `setFilter` removing an absent filter. No spurious events.
+
+4. **`teardown` is idempotent**. Calling it on a table that was never
+   touched is a no-op (no `tbody` mutation).
+
+5. **`revision` strictly increases** with every emission, even when
+   `entries` is reference-equal to the prior emission.
+
+6. **All public functions accept the live `HTMLTableElement`** — no
+   string-id lookup at this layer (the top-level `window.gridSight`
+   wrappers in `src/index.ts` do that translation, mirroring how
+   sliders work in spec 001).
+
+7. **No public function throws** for benign cases (missing column,
+   missing table state). They return / no-op silently, matching the
+   "directive for missing column → silently dropped" rule in the spec.
+   Programmer errors (passing `null` for `table`, non-numeric
+   `columnIndex`) MAY throw `TypeError`.
+
+---
+
+## Wiring expectations
+
+- `sort.ts` and `filter.ts` are the **only writers**. They call
+  `setSort` / `setFilter` from lozenge / popup event handlers and from
+  the URL-restore path.
+- `index.ts` adds NO new top-level `window.gridSight.*` for v1 — the
+  feature is wholly DOM-driven (lozenges + URL). The visible-rows API
+  is module-internal until a downstream feature ships that needs to
+  expose it programmatically. (This is a deliberate conservative move
+  per Development-Phase Posture: the surface is reserved internally,
+  promoted to `window.gridSight` only on first programmatic consumer.)
+- Downstream specs (`005`, `008`, `009`, `010`) MUST `import` the API
+  from `utils/visible-rows.ts` rather than read `tbody.rows`.
+
+---
+
+## Non-goals (out of contract)
+
+- **Async re-evaluation**: pipeline is sync. Consumers that need to
+  defer their own work to a frame MUST use their own `requestAnimationFrame`.
+- **Per-event diff**: listeners get the whole sequence; comparing
+  `revision` is the cheap "changed?" probe.
+- **Custom sort comparators**: not in v1 (spec Assumptions). The
+  comparator is internal.
+- **Row removal**: filter dims; it does not remove. There is no API to
+  "hide" a row.

--- a/specs/002-003-row-visibility/data-model.md
+++ b/specs/002-003-row-visibility/data-model.md
@@ -1,0 +1,216 @@
+# Phase 1 — Data Model: Row Visibility & Order (Sort + Filter)
+
+**Spec**: [./spec.md](./spec.md) · **Plan**: [./plan.md](./plan.md) · **Research**: [./research.md](./research.md) · **Date**: 2026-05-19
+
+This document fixes the in-memory shapes that the pipeline operates on
+and that flow between modules. URL-fragment shapes are specified
+separately in [contracts/url-fragment-schema.md](./contracts/url-fragment-schema.md);
+the public read API is in [contracts/visible-rows-api.md](./contracts/visible-rows-api.md).
+
+---
+
+## VisibleRowEntry
+
+The atom of the pipeline's output. One per `<tr>` in `tbody`, in render
+order.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `row` | `HTMLTableRowElement` | Live reference to the actual `<tr>`. Do not clone. |
+| `dimmed` | `boolean` | `true` if any active filter predicate returned `false` for this row. |
+| `sourceIndex` | `number` | Zero-based index into the Original Order Record. Stable for the lifetime of the table; survives sort. |
+
+**Invariants**:
+- `entries.length === tbody.rows.length` at all times.
+- `entries.filter(e => !e.dimmed)` is in sort order (or original order
+  if no sort is active).
+- `entries.filter(e => e.dimmed)` retains relative original order.
+
+---
+
+## VisibleRowSequence
+
+The full output shape, returned by `getVisibleRows(table)` and passed to
+every `onChange` listener.
+
+```ts
+interface VisibleRowSequence {
+  /** All rows in render order. */
+  readonly entries: readonly VisibleRowEntry[];
+  /** The active sort, or null if idle. */
+  readonly sort: SortDirective | null;
+  /** All active filter predicates, keyed by column index. AND-composed. */
+  readonly filters: ReadonlyMap<number, FilterPredicate>;
+  /** Monotonically increasing per-table revision counter. */
+  readonly revision: number;
+}
+```
+
+**Why `revision`**: Downstream consumers (especially the cumulative-
+column and copy-as-CSV features) need a cheap "did anything change?"
+check that survives equal-reference re-emissions; comparing `revision`
+is O(1).
+
+---
+
+## SortDirective
+
+```ts
+interface SortDirective {
+  /** Zero-based index into the column array. */
+  readonly columnIndex: number;
+  /** Stable column key (header text slugged via R-4). Used in URL serialisation. */
+  readonly columnKey: string;
+  readonly direction: 'asc' | 'desc';
+}
+```
+
+**Lifecycle**:
+- `null` → `{ asc }` → `{ desc }` → `null` on successive lozenge clicks
+  (`002` US1 contract).
+- At most one `SortDirective` per table at any time.
+
+---
+
+## FilterPredicate
+
+The internal shape filter modules produce and the pipeline consumes.
+
+```ts
+interface FilterPredicate {
+  readonly columnIndex: number;
+  readonly columnKey: string;
+  /** True if the row PASSES the filter (i.e. NOT dimmed). */
+  test(row: HTMLTableRowElement): boolean;
+  /** Stable serialisable form for URL persistence. Never `null`. */
+  toDirective(): FilterDirective;
+}
+
+type FilterDirective =
+  | { kind: 'numeric-range'; columnKey: string; min: number | null; max: number | null; hideEmpty: boolean }
+  | { kind: 'categorical'; columnKey: string; allowed: readonly string[]; hideEmpty: boolean };
+```
+
+Active predicates compose with logical AND. Within a categorical popup,
+the `allowed` set expresses per-column OR (as specified in `003`).
+
+---
+
+## OriginalOrderRecord (OOR)
+
+```ts
+type OriginalOrderRecord = readonly HTMLTableRowElement[];
+```
+
+Held in a module-scoped `WeakMap<HTMLTableElement, OriginalOrderRecord>`.
+Captured exactly once per table, at first activation of either the sort
+lozenge or any filter lozenge. Cleared on `teardown(table)`.
+
+**Capture rule (FR-VP-005)**:
+```ts
+if (!oor.has(table)) oor.set(table, Array.from(table.tBodies[0].rows));
+```
+
+---
+
+## PipelineState (internal)
+
+Not part of the public API; held in a per-table closure inside
+`utils/visible-rows.ts`.
+
+```ts
+interface PipelineState {
+  table: HTMLTableElement;
+  sort: SortDirective | null;
+  filters: Map<number, FilterPredicate>;
+  oor: OriginalOrderRecord | null;
+  revision: number;
+  listeners: Set<(seq: VisibleRowSequence) => void>;
+}
+```
+
+`revision` increments before any listener fires.
+
+---
+
+## Computed re-evaluation flow
+
+```text
+applyChange(state, patch)
+  1. mutate state.sort or state.filters per patch
+  2. if state.oor is null:
+       capture OOR (R-3)
+  3. compute pass list:
+       pass[i] = every active filter.test(oor[i]) === true
+  4. compute order:
+       if state.sort is null:
+         renderOrder = oor.map(i)
+       else:
+         visible   = oor.filter((_, i) => pass[i])
+         dimmed    = oor.filter((_, i) => !pass[i])  // keeps original order
+         visible.sort(comparator(state.sort))
+         renderOrder = mergeByOriginalIndex(visible, dimmed)
+                        // re-interleave dimmed rows at their original
+                        // sourceIndex positions; visible rows fill the gaps
+                        // in sort order.
+  5. reorder tbody DOM to match renderOrder
+  6. set/clear data-gs-dimmed on each row
+  7. update aria-sort on the sorted column header (if any)
+  8. state.revision += 1
+  9. fire listeners synchronously (R-8)
+```
+
+**`mergeByOriginalIndex` semantics** (FR-VP-004): the un-dimmed rows are
+placed in sort order; the dimmed rows occupy their original positions
+relative to one another. Concretely:
+- Walk `oor` in original order. Each slot either belongs to a dimmed
+  row (in which case the dimmed row stays there) or to a visible row
+  (in which case the next visible row from the sorted list fills the
+  slot).
+- This means the dimmed rows act as anchors and the visible rows
+  "slot in" between them in sort order. Settles US5 AS-1 precisely:
+  filtering dims rows `[1, 3]`, sorting puts `[2, 4, 5]` in desc order
+  through the un-dimmed slots → final order is `[2-or-4-or-5, 1, 2-or-4-or-5, 3, …]`
+  with the visible slots filled descending.
+
+---
+
+## State transitions
+
+| Event | Sort | Filters | OOR captured? |
+|-------|------|---------|---------------|
+| First sort click | `null → asc` | unchanged | Yes (if not already) |
+| Second sort click | `asc → desc` | unchanged | unchanged |
+| Third sort click | `desc → null` | unchanged | unchanged |
+| Add filter on column N | unchanged | `filters.set(N, predicate)` | Yes (if not already) |
+| Update filter on column N | unchanged | `filters.set(N, newPredicate)` | unchanged |
+| Remove filter on column N | unchanged | `filters.delete(N)` | unchanged |
+| Clear all filters | unchanged | `filters.clear()` | unchanged |
+| URL restore on first load | applied from directive | applied from directives (before sort) | Yes (synchronously, before paint) |
+| `teardown(table)` | `null` | empty | OOR restored to DOM, then cleared |
+
+---
+
+## Persisted View State (URL shape, summary)
+
+Full grammar lives in
+[contracts/url-fragment-schema.md](./contracts/url-fragment-schema.md).
+Summary:
+
+```text
+gs.v=<table-id>(s:<colKey>:<asc|desc>)(f:<colKey>:<predicateBody>)(...)
+```
+
+Per FR-VP-007 filters are listed before sort in the directive; the
+codec also reapplies them in that order on load (filters first, then
+sort) so the restored view is identical to the live view.
+
+---
+
+## Edge-case clarifications
+
+- **Empty tables**: pipeline emits `{ entries: [], sort: null, filters: empty, revision: ≥ 1 }`. Lozenges are not injected on empty tables (existing `header-utils` guard).
+- **`rowspan`/`colspan` body cells**: per `002` and `003` edge cases, both lozenges are suppressed for columns whose body cells span rows. The pipeline still operates, but the sort comparator and filter `.test()` short-circuit on the suppressed column.
+- **Zero-match filter**: `entries.every(e => e.dimmed)` is the trigger for the empty-state message (`003` US3 / new combination case). The pipeline does not own the message — `filter-chip.ts` reads `entries` and renders.
+- **Multi-section tables**: only `tbody[0]` rows participate. `thead` and `tfoot` are untouched.
+- **`data-gs-ignore` / `data-gs-no-sort` / `data-gs-no-filter`**: read by the lozenge injectors before they offer the affordance. Pipeline is never asked to operate on suppressed columns.

--- a/specs/002-003-row-visibility/data-model.md
+++ b/specs/002-003-row-visibility/data-model.md
@@ -21,6 +21,7 @@ order.
 | `sourceIndex` | `number` | Zero-based index into the Original Order Record. Stable for the lifetime of the table; survives sort. |
 
 **Invariants**:
+
 - `entries.length === tbody.rows.length` at all times.
 - `entries.filter(e => !e.dimmed)` is in sort order (or original order
   if no sort is active).
@@ -66,6 +67,7 @@ interface SortDirective {
 ```
 
 **Lifecycle**:
+
 - `null` → `{ asc }` → `{ desc }` → `null` on successive lozenge clicks
   (`002` US1 contract).
 - At most one `SortDirective` per table at any time.
@@ -107,6 +109,7 @@ Captured exactly once per table, at first activation of either the sort
 lozenge or any filter lozenge. Cleared on `teardown(table)`.
 
 **Capture rule (FR-VP-005)**:
+
 ```ts
 if (!oor.has(table)) oor.set(table, Array.from(table.tBodies[0].rows));
 ```
@@ -163,6 +166,7 @@ applyChange(state, patch)
 **`mergeByOriginalIndex` semantics** (FR-VP-004): the un-dimmed rows are
 placed in sort order; the dimmed rows occupy their original positions
 relative to one another. Concretely:
+
 - Walk `oor` in original order. Each slot either belongs to a dimmed
   row (in which case the dimmed row stays there) or to a visible row
   (in which case the next visible row from the sorted list fills the

--- a/specs/002-003-row-visibility/plan.md
+++ b/specs/002-003-row-visibility/plan.md
@@ -1,0 +1,177 @@
+# Implementation Plan: Row Visibility & Order (Sort + Filter)
+
+**Branch**: `claude/row-visibility-spec-UxTM5` | **Date**: 2026-05-19 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/002-003-row-visibility/spec.md`
+**Source specs (superseded for planning only)**: [`specs/002-sort/spec.md`](../002-sort/spec.md), [`specs/003-filter/spec.md`](../003-filter/spec.md)
+
+## Summary
+
+Land a single **Visible Row Sequence** pipeline that owns the table's row
+projection — what order rows appear in (sort) and which ones are dimmed
+(filter) — and expose it as the only sanctioned read-channel for every
+downstream enrichment (`005-sparkline`, `008-cumulative-column`,
+`009-copy-as-csv`, `010-diff-compare`). The pipeline is filter-then-sort
+with dimming (not removal), one composed URL-fragment directive per table
+under a per-page namespace that mirrors `src/utils/slider-persistence.ts`,
+a one-shot Original Order Record captured at first activation of either
+lozenge, and a synchronous change event so consumers re-render within one
+animation frame. Sort and filter ship as separate priorities against this
+shared scaffold: the pipeline lands first as an identity projection with
+the public API frozen; sort, filter (numeric), filter (categorical), the
+clear-all chip, sort-over-filter semantics, and URL persistence layer in
+on top in user-story order.
+
+## Technical Context
+
+**Language/Version**: TypeScript ~5.8 (project compiler; emits ES2020+).
+**Primary Dependencies**:
+  - Runtime: **none new**. Comparison uses `Array.prototype.sort` +
+    `Intl.Collator`; filtering uses `Number`, `String.prototype.trim`, and
+    `Intl.Collator` where needed. Existing `simple-statistics` and
+    `shepherd.js` are unrelated and remain untouched.
+  - Build/test: existing Vite 6, Vitest 3, Playwright 1.53, Storybook 9.
+**Storage**: URL fragment only (no `localStorage`). One namespace per page,
+  one directive object per table, sort and filter under a single object —
+  no separate keys. Mirrors the per-URL-stem scheme of
+  `src/utils/slider-persistence.ts` (origin + pathname stem) but does not
+  share its `gs.s` key.
+**Testing**: Vitest unit tests (per-folder `__tests__/`) for the pipeline,
+  comparator, filter predicates, URL codec, and Original Order Record;
+  Storybook 9 interaction tests (`@storybook/addon-vitest`) for lozenge
+  popups, chip, keyboard contract; Playwright e2e for the four golden
+  flows (sort-only, filter-only, sort-over-filter, URL round-trip on a
+  fresh browser).
+**Target Platform**: Evergreen browsers released within the last two years
+  (constitution §V). Must work from `file://` (constitution §VI).
+**Project Type**: Browser library, single project. IIFE bundle
+  (`dist/grid-sight.iife.js`) + npm/ESM via `src/index.ts`.
+**Performance Goals**:
+  - 1 000-row table: sort, filter, or combined re-evaluation completes in
+    **< 100 ms** on a mid-range laptop (SC-002 = constitution §runtime
+    budget).
+  - URL restore visible **within one animation frame** of first paint
+    (SC-003).
+  - Pipeline `onChange` emits **synchronously** so downstream
+    re-renders settle in the same frame (FR-VP-003).
+**Constraints**:
+  - Bundle delta for this feature must keep the IIFE ≤ 10 KB gzipped
+    (constitution §I). Target: ≤ 2.0 KB gzipped net delta for the
+    combined sort + filter + pipeline + URL codec.
+  - No runtime network access. No new runtime deps (constitution §VI, §I).
+  - **Byte-identical DOM on toggle-off** (SC-005): no leftover classes,
+    attributes, or injected nodes from the projection. The Original Order
+    Record is the means by which we guarantee this.
+  - Keyboard + AT operability mandatory (constitution §III). Filter
+    popups need a focus trap; sort lozenge announces next action.
+**Scale/Scope**: Up to ~10 tables per page, each up to ~1 000 rows × ~50
+  columns. One sort directive per table; up to one filter predicate per
+  column.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Evaluated against `.specify/memory/constitution.md` v1.1.0:
+
+| Principle | Verdict | Notes |
+|-----------|---------|-------|
+| I. Lightweight & Minimal Dependencies | ✅ Pass | No new runtime deps; net IIFE delta budgeted ≤ 2 KB gzipped. Bundle measured each PR by `scripts/bundle-size.js`. |
+| II. Test Discipline | ✅ Pass | Pipeline + comparator + URL codec covered by Vitest unit suite; lozenge / popup / chip covered by Storybook interaction tests; four golden flows covered by Playwright. SC-006 adds an automated parity check between pipeline output and rendered DOM. |
+| III. Accessibility by Default | ✅ Pass | Sort lozenge sets `aria-sort` and announces the next action; filter lozenge uses `aria-pressed`; popups trap focus; chip is keyboard-reachable; dimmed rows remain announced (no `aria-hidden`). Carried verbatim from the source specs and unchanged here. |
+| IV. Progressive Enhancement | ✅ Pass | Pipeline starts as an identity projection; no DOM mutation until a user activates a lozenge. Toggling Grid-Sight off restores byte-identical DOM (SC-005). |
+| V. Cross-Browser Compatibility | ✅ Pass | Only `Array.prototype.sort` (stable since ES2019), `Intl.Collator`, `URLSearchParams`, `requestAnimationFrame`, and standard DOM APIs. All > 2 years across every evergreen engine. No feature-detection needed. |
+| VI. Offline-First / Air-Gapped | ✅ Pass | URL fragment only; no `localStorage` reliance (explicit non-goal in SC-004); zero network calls anywhere on the runtime path. |
+| Development-Phase Posture | N/A | Pre-production; the spec's URL-fragment shape and the `utils/visible-rows.ts` API are explicitly allowed to evolve before the production cut. |
+
+**No constitution violations.** Complexity Tracking section is intentionally empty.
+
+**Post-design re-check (2026-05-19)**: After producing `research.md`,
+`data-model.md`, `contracts/visible-rows-api.md`,
+`contracts/url-fragment-schema.md`, and `quickstart.md`, every gate was
+re-evaluated against the concrete shapes proposed. No new dependency, no
+network call, no fall-back to `localStorage`, no API outside the published
+contract; bundle estimate (research R-7) stays inside the 2 KB net budget.
+Verdict unchanged: passing on every principle.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-003-row-visibility/
+├── plan.md                       # This file (/speckit-plan output)
+├── spec.md                       # Feature specification (input)
+├── research.md                   # Phase 0 — pipeline / URL / sort / filter decisions
+├── data-model.md                 # Phase 1 — Visible Row Sequence, directives, Original Order Record
+├── quickstart.md                 # Phase 1 — wire a downstream enrichment to the pipeline in < 5 min
+├── contracts/
+│   ├── visible-rows-api.md       # Phase 1 — utils/visible-rows.ts surface
+│   └── url-fragment-schema.md    # Phase 1 — combined sort+filter directive shape
+├── checklists/
+│   └── requirements.md           # Spec validation (already passing 12/15; 3 accepted exceptions)
+└── tasks.md                      # Phase 2 output — created by /speckit-tasks (not here)
+```
+
+### Source Code (repository root)
+
+Existing single-project layout is reused; this feature adds files under
+the existing top-level groupings rather than introducing new top-level
+directories.
+
+```text
+src/
+├── core/                                       # existing — unchanged
+├── enrichments/
+│   ├── sort.ts                                 # NEW — sort directive, comparator, lozenge wiring
+│   ├── filter.ts                               # NEW — filter predicates (numeric range, categorical), popup orchestration
+│   ├── filter-chip.ts                          # NEW — clear-all chip + per-filter summary
+│   └── ...                                     # existing enrichments unchanged
+├── ui/
+│   ├── sort-lozenge.ts                         # NEW — ↕ lozenge button + aria-sort handling
+│   ├── filter-lozenge.ts                       # NEW — ▽ lozenge button + popup trigger
+│   ├── filter-popup-numeric.ts                 # NEW — Min/Max inputs, "Hide empty cells" toggle
+│   ├── filter-popup-categorical.ts             # NEW — count-labelled checkboxes, search, select-all/none
+│   ├── header-utils.ts                         # MODIFIED — register sort + filter in the lozenge cluster
+│   └── ...                                     # existing UI unchanged
+├── utils/
+│   ├── visible-rows.ts                         # NEW — Visible Row Sequence pipeline (the public hub)
+│   ├── original-order.ts                       # NEW — one-shot snapshot per table
+│   ├── view-state-url.ts                       # NEW — combined sort+filter URL codec (separate from slider-persistence)
+│   └── ...                                     # existing utils unchanged
+└── index.ts                                    # MODIFIED — re-export visible-rows public surface; no breaking change to existing exports
+
+src/enrichments/__tests__/
+├── sort.test.ts                                # NEW
+├── filter.test.ts                              # NEW
+└── filter-chip.test.ts                         # NEW
+
+src/ui/__tests__/
+├── sort-lozenge.test.ts                        # NEW
+├── filter-popup-numeric.test.ts                # NEW
+└── filter-popup-categorical.test.ts            # NEW
+
+src/utils/__tests__/
+├── visible-rows.test.ts                        # NEW — pipeline composition + change event
+├── original-order.test.ts                      # NEW — snapshot capture timing
+└── view-state-url.test.ts                      # NEW — codec round-trip + missing-target drop
+
+tests/e2e/
+├── sort.spec.ts                                # NEW — Playwright: three-state sort
+├── filter.spec.ts                              # NEW — Playwright: numeric + categorical filters
+├── sort-over-filter.spec.ts                    # NEW — Playwright: US5 golden path
+└── view-state-url.spec.ts                      # NEW — Playwright: shareable URL round-trip on a clean profile
+```
+
+**Structure Decision**: Reuse the existing single-project layout. The
+**only architectural addition** is `src/utils/visible-rows.ts` as the
+shared hub. Sort and filter both live in `src/enrichments/` and are
+the only modules that mutate pipeline state; every downstream feature
+reads from `visible-rows.ts` and never touches `tbody` directly. This
+mirrors how `src/enrichments/slider.ts` and
+`src/ui/slider-control.ts` are layered for spec 001.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+No violations. Section intentionally empty.

--- a/specs/002-003-row-visibility/plan.md
+++ b/specs/002-003-row-visibility/plan.md
@@ -25,47 +25,57 @@ on top in user-story order.
 
 **Language/Version**: TypeScript ~5.8 (project compiler; emits ES2020+).
 **Primary Dependencies**:
-  - Runtime: **none new**. Comparison uses `Array.prototype.sort` +
-    `Intl.Collator`; filtering uses `Number`, `String.prototype.trim`, and
-    `Intl.Collator` where needed. Existing `simple-statistics` and
-    `shepherd.js` are unrelated and remain untouched.
-  - Build/test: existing Vite 6, Vitest 3, Playwright 1.53, Storybook 9.
+
+- Runtime: **none new**. Comparison uses `Array.prototype.sort` +
+  `Intl.Collator`; filtering uses `Number`, `String.prototype.trim`, and
+  `Intl.Collator` where needed. Existing `simple-statistics` and
+  `shepherd.js` are unrelated and remain untouched.
+- Build/test: existing Vite 6, Vitest 3, Playwright 1.53, Storybook 9.
+
 **Storage**: URL fragment only (no `localStorage`). One namespace per page,
-  one directive object per table, sort and filter under a single object —
-  no separate keys. Mirrors the per-URL-stem scheme of
-  `src/utils/slider-persistence.ts` (origin + pathname stem) but does not
-  share its `gs.s` key.
+one directive object per table, sort and filter under a single object —
+no separate keys. Mirrors the per-URL-stem scheme of
+`src/utils/slider-persistence.ts` (origin + pathname stem) but does not
+share its `gs.s` key.
+
 **Testing**: Vitest unit tests (per-folder `__tests__/`) for the pipeline,
-  comparator, filter predicates, URL codec, and Original Order Record;
-  Storybook 9 interaction tests (`@storybook/addon-vitest`) for lozenge
-  popups, chip, keyboard contract; Playwright e2e for the four golden
-  flows (sort-only, filter-only, sort-over-filter, URL round-trip on a
-  fresh browser).
+comparator, filter predicates, URL codec, and Original Order Record;
+Storybook 9 interaction tests (`@storybook/addon-vitest`) for lozenge
+popups, chip, keyboard contract; Playwright e2e for the four golden
+flows (sort-only, filter-only, sort-over-filter, URL round-trip on a
+fresh browser).
+
 **Target Platform**: Evergreen browsers released within the last two years
-  (constitution §V). Must work from `file://` (constitution §VI).
+(constitution §V). Must work from `file://` (constitution §VI).
+
 **Project Type**: Browser library, single project. IIFE bundle
-  (`dist/grid-sight.iife.js`) + npm/ESM via `src/index.ts`.
+(`dist/grid-sight.iife.js`) + npm/ESM via `src/index.ts`.
+
 **Performance Goals**:
-  - 1 000-row table: sort, filter, or combined re-evaluation completes in
-    **< 100 ms** on a mid-range laptop (SC-002 = constitution §runtime
-    budget).
-  - URL restore visible **within one animation frame** of first paint
-    (SC-003).
-  - Pipeline `onChange` emits **synchronously** so downstream
-    re-renders settle in the same frame (FR-VP-003).
+
+- 1 000-row table: sort, filter, or combined re-evaluation completes in
+  **< 100 ms** on a mid-range laptop (SC-002 = constitution §runtime
+  budget).
+- URL restore visible **within one animation frame** of first paint
+  (SC-003).
+- Pipeline `onChange` emits **synchronously** so downstream
+  re-renders settle in the same frame (FR-VP-003).
+
 **Constraints**:
-  - Bundle delta for this feature must keep the IIFE ≤ 10 KB gzipped
-    (constitution §I). Target: ≤ 2.0 KB gzipped net delta for the
-    combined sort + filter + pipeline + URL codec.
-  - No runtime network access. No new runtime deps (constitution §VI, §I).
-  - **Byte-identical DOM on toggle-off** (SC-005): no leftover classes,
-    attributes, or injected nodes from the projection. The Original Order
-    Record is the means by which we guarantee this.
-  - Keyboard + AT operability mandatory (constitution §III). Filter
-    popups need a focus trap; sort lozenge announces next action.
+
+- Bundle delta for this feature must keep the IIFE ≤ 10 KB gzipped
+  (constitution §I). Target: ≤ 2.0 KB gzipped net delta for the
+  combined sort + filter + pipeline + URL codec.
+- No runtime network access. No new runtime deps (constitution §VI, §I).
+- **Byte-identical DOM on toggle-off** (SC-005): no leftover classes,
+  attributes, or injected nodes from the projection. The Original Order
+  Record is the means by which we guarantee this.
+- Keyboard + AT operability mandatory (constitution §III). Filter
+  popups need a focus trap; sort lozenge announces next action.
+
 **Scale/Scope**: Up to ~10 tables per page, each up to ~1 000 rows × ~50
-  columns. One sort directive per table; up to one filter predicate per
-  column.
+columns. One sort directive per table; up to one filter predicate per
+column.
 
 ## Constitution Check
 

--- a/specs/002-003-row-visibility/quickstart.md
+++ b/specs/002-003-row-visibility/quickstart.md
@@ -1,0 +1,143 @@
+# Quickstart: Read from the Visible Row pipeline
+
+**Spec**: [./spec.md](./spec.md) · **Plan**: [./plan.md](./plan.md) · **Contract**: [./contracts/visible-rows-api.md](./contracts/visible-rows-api.md) · **Date**: 2026-05-19
+
+This is the cheat-sheet for the engineer landing one of the downstream
+specs (`005-sparkline`, `008-cumulative-column`, `009-copy-as-csv`,
+`010-diff-compare`) and wiring it to the Row Visibility pipeline.
+
+Time to working code: **< 5 minutes**.
+
+---
+
+## TL;DR
+
+```ts
+import { getVisibleRows, onVisibleRowsChange } from '../utils/visible-rows';
+
+function attachMyEnrichment(table: HTMLTableElement) {
+  // Initial render uses the current projection.
+  render(table, getVisibleRows(table));
+
+  // Re-render on every change. Listener fires synchronously, so this is
+  // in the same frame as the user click that triggered the change.
+  const unsubscribe = onVisibleRowsChange(table, (seq) => render(table, seq));
+
+  // Call unsubscribe() in your teardown path.
+  return unsubscribe;
+}
+
+function render(_table: HTMLTableElement, seq: VisibleRowSequence) {
+  for (const { row, dimmed, sourceIndex } of seq.entries) {
+    if (dimmed) continue;          // skip dimmed rows for aggregations
+    // …your per-row work, in render order…
+  }
+}
+```
+
+That is the whole API for read-only consumers.
+
+---
+
+## Do
+
+- **Read row order through `seq.entries`**, not `tbody.rows`. The two
+  differ whenever sort or filter is active.
+- **Skip dimmed rows for aggregations** (running totals, sparkline
+  shared scale, copy-as-CSV, statistics). Dimmed rows are still in the
+  DOM but the user does not want them counted in derived values.
+- **Use `sourceIndex` as a stable per-row identity** across re-renders.
+  It survives sort and filter changes.
+- **Compare `seq.revision`** when you want a cheap "did anything
+  change?" guard.
+- **Unsubscribe in your teardown path** to avoid leaking listeners when
+  Grid-Sight is disabled on the table.
+
+## Don't
+
+- **Don't read `tbody.rows` directly** — you will miss sort, and you
+  will count dimmed rows.
+- **Don't mutate `seq.entries`** — it is `readonly`. Make a local copy
+  if you need to.
+- **Don't queue your work with `setTimeout` or `queueMicrotask`** when
+  the user's intent is "see the result of this click immediately".
+  Re-render synchronously inside the listener.
+- **Don't call `setSort` / `setFilter` from a downstream enrichment**.
+  Those are reserved for `sort.ts` and `filter.ts`. If your feature
+  needs to drive the projection, file a spec amendment.
+
+---
+
+## Common patterns
+
+### Running total over the visible block
+
+```ts
+onVisibleRowsChange(table, (seq) => {
+  let running = 0;
+  for (const e of seq.entries) {
+    if (e.dimmed) {
+      cell(e.row, totalsColIdx).textContent = '';   // blank for dimmed
+      continue;
+    }
+    running += readNumeric(cell(e.row, sourceColIdx));
+    cell(e.row, totalsColIdx).textContent = format(running);
+  }
+});
+```
+
+### Copy-as-CSV "current view"
+
+```ts
+const seq = getVisibleRows(table);
+const lines = seq.entries
+  .filter(e => !e.dimmed)
+  .map(e => Array.from(e.row.cells).map(csvEscape).join(','));
+return lines.join('\n');
+```
+
+### Sparkline shared scale across rows of the visible block
+
+```ts
+const seq = getVisibleRows(table);
+const visibleValues = seq.entries
+  .filter(e => !e.dimmed)
+  .map(e => readNumeric(cell(e.row, valueColIdx)));
+const scale = { min: Math.min(...visibleValues), max: Math.max(...visibleValues) };
+```
+
+### Diff-compare "are these two tables showing the same rows in the same order?"
+
+```ts
+const a = getVisibleRows(tableA);
+const b = getVisibleRows(tableB);
+if (a.revision !== prevA || b.revision !== prevB) {
+  recomputeDiff(a, b);
+  prevA = a.revision; prevB = b.revision;
+}
+```
+
+---
+
+## Manual smoke test (no test runner needed)
+
+1. Open any demo page that loads `dist/grid-sight.iife.js`.
+2. Click the **↕** (sort) lozenge on a numeric column → rows reorder asc, then desc, then back to original on three clicks.
+3. Click the **▽** (filter) lozenge on the same column → enter `100`–`500` → rows outside the range dim. Sort still applies to the un-dimmed block (US5).
+4. Copy `location.href`, open in a new private window → identical view, same sort, same dim set, no flash (SC-003 + SC-004).
+5. Toggle Grid-Sight off via the page-level toggle → `tbody.innerHTML` byte-identical to before init (SC-005).
+
+If any of those fail, the feature is not done. The four steps map 1:1 to the Playwright golden flows in `tests/e2e/*.spec.ts`.
+
+---
+
+## Where to look in the source tree
+
+| You want to… | File |
+|--------------|------|
+| Read the projection | `src/utils/visible-rows.ts` |
+| Drive sort | `src/enrichments/sort.ts` |
+| Drive filter | `src/enrichments/filter.ts` |
+| See the lozenge wiring | `src/ui/header-utils.ts` |
+| See URL persistence | `src/utils/view-state-url.ts` |
+| See teardown | `src/utils/visible-rows.ts` → `teardown(table)` |

--- a/specs/002-003-row-visibility/research.md
+++ b/specs/002-003-row-visibility/research.md
@@ -1,0 +1,347 @@
+# Phase 0 — Research: Row Visibility & Order (Sort + Filter)
+
+**Spec**: [./spec.md](./spec.md) · **Plan**: [./plan.md](./plan.md) · **Date**: 2026-05-19
+
+This document resolves every open design question raised by the spec's
+"Requirements" and "Assumptions" sections. There are **zero**
+`[NEEDS CLARIFICATION]` markers in the spec (validated in
+`checklists/requirements.md`); the entries below are the planning
+decisions, their rationale, and the alternatives that were considered and
+rejected.
+
+---
+
+## R-1 — Pipeline ordering: filter, then sort, always
+
+**Decision**: The Visible Row Sequence is computed as
+`sort(filter(rows))` for every change. There is no user-visible knob to
+invert this. Sort operates only on rows where `dimmed = false`; dimmed
+rows retain their original `sourceIndex` and are never lifted into the
+visible block.
+
+**Rationale**: Matches the natural user mental model from US5
+("show me orders over $100, biggest first"). Settles the implicit
+question both source specs left open — `002-sort` US1 AS-1..AS-4
+silently assumed no filter, `003-filter` US1 AS-1..AS-4 silently
+assumed no sort. Without this rule, every downstream consumer
+(`005`, `008`, `009`, `010`) would have to invent its own answer.
+
+**Alternatives considered**:
+- *Sort-then-filter*: equivalent for predicate-only filters (filter is
+  position-independent), but the rendered DOM differs because dimmed
+  rows would have to move. Rejected — violates SC-005 (byte-identical
+  DOM restore) and the "dim, not hide" assumption.
+- *User-selectable order*: adds UI surface, doc burden, and an extra URL
+  field, with no concrete use case. Rejected as YAGNI.
+
+---
+
+## R-2 — Dim, not hide
+
+**Decision**: Filter marks rows with `data-gs-dimmed="true"` plus a
+class hook (e.g. `gs-row--dimmed`) and a CSS opacity reduction. Rows are
+never removed from the DOM, never wrapped, and `display: none` is never
+used.
+
+**Rationale**: Carried verbatim from `003-filter`. Preserves row indices
+for downstream features that hold references (e.g. cumulative-column),
+keeps screen-reader output stable, and supports SC-005 by restoring with
+a single attribute + class removal pass. Also makes the FR-VP-004 rule
+("sort only un-dimmed rows") trivially expressible.
+
+**Alternatives considered**:
+- *`display: none`*: shorter CSS but breaks SC-005 (the row's box is
+  gone) and screen-reader announcement (`003` FR-022 forbids it).
+  Rejected.
+- *`hidden` attribute*: same screen-reader objection. Rejected.
+- *Detach + reattach*: would lose original position and require a
+  separate placeholder map. Rejected as more complex.
+
+---
+
+## R-3 — Original Order Record: captured once, at first activation of either lozenge
+
+**Decision**: The first time *either* the sort lozenge or any filter
+lozenge transitions a table out of "idle", the pipeline snapshots
+`Array.from(tbody.rows)` and stores it as the **Original Order Record**
+(OOR) on a `WeakMap<HTMLTableElement, HTMLTableRowElement[]>`. Toggling
+both projections off restores `tbody` to that order; toggling
+Grid-Sight off discards the OOR after the restore.
+
+**Rationale**: Reconciles the two source specs — `002-sort` captured on
+first sort, `003-filter` captured on first filter. The combined spec
+(FR-VP-005) demands one OOR per table, captured on whichever happens
+first, because either projection can be the user's first action.
+
+**Alternatives considered**:
+- *Capture at table-process time*: simpler, but mutates the OOR scope
+  (every table on the page pays the snapshot cost, even those never
+  enriched). Rejected — violates progressive enhancement.
+- *Re-snapshot on every change*: would lose the original order as soon
+  as the user did anything. Rejected — defeats the purpose.
+
+---
+
+## R-4 — URL persistence: one fragment namespace, one directive object per table, sort+filter under one object
+
+**Decision**: A single URL-fragment parameter, **`gs.v`** (for "view"),
+holds a comma-separated list of per-table directive objects, each of the
+shape:
+
+```text
+<table-id>{sort?}{filters?}
+```
+
+Encoded compactly as URL-safe ASCII; the parser is the only public
+authority on shape. The full grammar lives in
+[contracts/url-fragment-schema.md](./contracts/url-fragment-schema.md).
+This is **separate** from `gs.s` (sliders, owned by spec 001) — they
+co-exist in the same fragment, both keyed by the per-URL-stem scheme
+(origin + pathname) already used by `src/utils/slider-persistence.ts`,
+but they do not share a parameter or a codec.
+
+**Rationale**: Satisfies FR-VP-006 (single namespace per page) and
+FR-VP-007 (filters applied before sort on load → reproduce a
+sort-of-filtered-view identically). Keeping `gs.v` distinct from `gs.s`
+means slider persistence and view-state persistence evolve independently
+— important because slider state is per-slider while view state is
+per-table.
+
+**Alternatives considered**:
+- *Reuse `gs.s`*: would tangle two unrelated state shapes in one codec.
+  Rejected.
+- *Per-table fragment key (`gs.v.<id>=...`)*: blows up the parameter
+  count and harms readability. Rejected.
+- *Encode filters and sort as separate parameters (`gs.sort=`, `gs.filt=`)*:
+  splits the "applied filter then sort" guarantee across two parameters
+  with unspecified ordering on parse. Rejected.
+
+**Open at plan time, locked here**: directive serialisation. Numeric
+range = `min:max` with empty strings for open bounds; categorical =
+`v:a|b|c` (URL-encoded); sort = `s:<col-key>:asc` or `s:<col-key>:desc`;
+column key = column header text after `String.prototype.trim()` and a
+deterministic slug (`/^[a-z0-9-]+$/`, fall back to `c<columnIndex>` if
+empty). Missing target columns or tables are silently dropped per the
+spec (US6 acceptance + FR-VP-007 prose).
+
+---
+
+## R-5 — Sort: stable, locale-aware, type-routed
+
+**Decision**:
+- Use `Array.prototype.sort` (stable since ES2019 across every evergreen
+  engine within the constitution's 2-year floor).
+- For numeric columns (typed via the existing `core/type-detection.ts`):
+  parse with the existing `cleanNumericCell`; sort by `Number` value;
+  `NaN` / blank cells sort to the end in both directions (matches the
+  `002` edge case for blanks).
+- For categorical / text columns: a single shared `Intl.Collator(undefined, { sensitivity: 'base', numeric: true })`
+  drives `.compare()`, giving us "natural" ordering ("file2" before
+  "file10") and locale-aware case folding.
+- Ties keep their original `sourceIndex` order — that is what
+  Array.sort already guarantees, no extra code needed.
+
+**Rationale**: Zero new dependencies, locale-correct, stable, and
+"natural sort" handles the mixed alphanumeric tables the demo pages
+already showcase. Edge case "non-monotonic mixed types" from `002`
+collapses naturally because the column-type detector already picks one
+type per column.
+
+**Alternatives considered**:
+- *Hand-rolled comparators per column*: more code, more bugs, no win
+  over `Intl.Collator`. Rejected.
+- *Adding a tiny dep like `natural-orderby`*: violates constitution §I
+  (no new runtime deps) for a problem `Intl.Collator` already solves.
+  Rejected.
+
+---
+
+## R-6 — Filter predicates: minimal closure, no DSL
+
+**Decision**: A filter predicate is a function
+`(row: HTMLTableRowElement) => boolean` (returns `true` if the row
+**passes** the filter, i.e. is NOT dimmed). The Active Filter Set is an
+array of predicates composed with logical AND. Two built-in predicate
+factories:
+- `numericRange({ min?, max?, hideEmpty? })` — open bounds allowed;
+  empty cells dimmed only if `hideEmpty` is `true` (per `003` US1 +
+  per-popup toggle).
+- `categoricalInclusion({ allowed: Set<string>, hideEmpty? })` — empty
+  string membership controlled by `hideEmpty`; values are read via
+  `textContent.trim()`.
+
+Both factories also expose a serialisable `toDirective()` so the URL
+codec never inspects predicate internals.
+
+**Rationale**: A closure-based predicate set is the smallest surface
+that satisfies FR-VP-001 and US4 (AND composition). Keeping the
+predicate as a function means custom filters (none planned for v1, but
+called out as an extension point) plug in without changing the pipeline.
+
+**Alternatives considered**:
+- *Object-based DSL (`{ op: 'between', min, max }`)*: more verbose for
+  no gain — the pipeline never introspects the predicate, only the URL
+  codec does, and it reads from `toDirective()`. Rejected.
+
+---
+
+## R-7 — Bundle-size budget
+
+**Decision**: Net IIFE delta budget for the combined feature is **≤ 2.0 KB
+gzipped**. Estimated split (after minification + gzip):
+
+| Module | Estimated gz |
+|--------|-------------:|
+| `utils/visible-rows.ts` | ~0.35 KB |
+| `utils/original-order.ts` | ~0.10 KB |
+| `utils/view-state-url.ts` (codec) | ~0.45 KB |
+| `enrichments/sort.ts` (comparator + lozenge wiring) | ~0.35 KB |
+| `enrichments/filter.ts` (predicate factories + popup orchestration) | ~0.40 KB |
+| `enrichments/filter-chip.ts` | ~0.15 KB |
+| `ui/sort-lozenge.ts` + `ui/filter-lozenge.ts` | ~0.10 KB |
+| `ui/filter-popup-numeric.ts` + `ui/filter-popup-categorical.ts` | ~0.10 KB |
+| Total estimate | **~2.00 KB** |
+
+`scripts/bundle-size.js` measures the live delta on every PR. If the
+total slips past 2 KB, the first PR that breaches MUST either trim or
+file a budget-raise note in `tasks.md`.
+
+**Rationale**: Constitution §I caps the IIFE at 10 KB gzipped. Spec 001
+already lives inside that ceiling (current measured ~5.8 KB total); a
+2 KB feature delta keeps total comfortably ≤ 8 KB with headroom for
+specs 004–010.
+
+---
+
+## R-8 — Synchronous change-event semantics
+
+**Decision**: `visible-rows` exposes a single subscription channel:
+
+```ts
+onChange(table: HTMLTableElement, listener: (seq: VisibleRowSequence) => void): () => void
+```
+
+The listener is invoked **synchronously** at the end of every
+re-evaluation (after the pipeline has updated DOM order and dim flags),
+before control returns to the caller that triggered the change. The
+returned closure unsubscribes.
+
+**Rationale**: FR-VP-003 demands that downstream enrichments re-render
+within one animation frame of the change. Synchronous emission is the
+only reliable way to keep them inside the same frame as the
+user-initiated event (`click`, `input`, popstate). Microtasks /
+`queueMicrotask` would also work in practice but introduce ordering
+hazards if the listener mutates a sibling enrichment's state.
+
+**Alternatives considered**:
+- *`requestAnimationFrame` batching inside the pipeline*: would
+  guarantee one frame of latency. Rejected — listeners that need to
+  batch can wrap their handler themselves.
+- *CustomEvent on the `tbody`*: leaks contract details into DOM
+  attributes (event name, payload shape) that would then need
+  versioning. Rejected.
+
+---
+
+## R-9 — Restore-before-paint on first load
+
+**Decision**: `gridSight.init()` reads `location.hash` synchronously
+during table processing and applies the persisted filter set + sort
+directive *before* `processTable` returns. The lozenge cluster mounts
+with the resulting state already reflected (sort indicator, filter chip
+present, dimmed rows already dim) so the first paint is the final paint.
+
+**Rationale**: Satisfies SC-003 ("restore the view with no visible
+flash beyond one animation frame after first paint"). Since the
+pipeline computes synchronously from in-memory state, there is no
+async barrier between parse and render.
+
+**Alternatives considered**:
+- *Apply via `DOMContentLoaded` listener after first paint*: produces
+  a visible flicker on slow devices. Rejected.
+- *Pre-render server-side*: not applicable — Grid-Sight is a
+  client-side library with no SSR story.
+
+---
+
+## R-10 — Composition with downstream consumers (`005`, `008`, `009`, `010`)
+
+**Decision**: Downstream specs read row order and visibility **only**
+via `utils/visible-rows.ts`. Each subscribes via `onChange` and
+re-renders on every emission. The Visible Row Sequence shape
+(`{ row, dimmed, sourceIndex }[]`) is the locked contract.
+
+**Rationale**: FR-VP-002 makes this the only sanctioned read-channel.
+Centralising prevents the situation where every downstream consumer
+reads `tbody.rows` directly and rediscovers the sort-over-filter rule.
+
+**Alternatives considered**:
+- *Document the rules and let each consumer reimplement*: would have
+  made this combined spec unnecessary. Rejected by the spec's own
+  framing.
+
+---
+
+## R-11 — Accessibility wiring
+
+**Decision**: Unchanged from the source specs.
+- Sort lozenge:
+  - `aria-sort` on the column header reflects `"ascending"`,
+    `"descending"`, or `"none"`.
+  - Accessible name describes the **next** action ("Sort Amount
+    descending").
+- Filter lozenge:
+  - `aria-pressed` reflects whether a filter is active on the column.
+  - Popup is a focus-trap (Tab cycles inside; Escape returns focus to
+    the lozenge).
+- Chip:
+  - Reachable via Tab from each filter lozenge; `Clear all filters`
+    button restores focus to the table's first focusable lozenge.
+- Dimmed rows:
+  - No `aria-hidden`; screen readers continue to announce the row.
+    Dim is visual only (CSS opacity).
+
+**Rationale**: Constitution §III mandates AT operability; every behaviour
+here is already specified verbatim in `002` and `003` and just needs
+to survive the combination.
+
+---
+
+## R-12 — Toggle-off → byte-identical DOM
+
+**Decision**: Disabling Grid-Sight (`gridSight.disable()` or removing
+the toggle) runs the pipeline's `teardown(table)` which:
+1. Restores `tbody` row order to the OOR if any change was applied.
+2. Removes `data-gs-dimmed` and `gs-row--dimmed` from every row.
+3. Removes `aria-sort` from every header cell touched.
+4. Removes sort/filter lozenges via `header-utils.removePlusIcons`.
+5. Deletes the OOR entry on the per-table WeakMap.
+
+URL state is **not** rewritten on teardown — toggling Grid-Sight back
+on re-applies the saved view (matches the "URL state remains so
+toggling back on re-applies both" edge case from `002`/`003`).
+
+**Rationale**: SC-005 demands byte-identical DOM. The teardown is the
+sole code path that achieves it; covered by a Vitest snapshot test
+(`tbody.innerHTML` before init vs after disable).
+
+---
+
+## Closed questions
+
+- "Should sort and filter share a URL fragment key?" → **Yes**, R-4.
+- "What happens to dimmed rows when a sort is applied?" → **Stay put**,
+  R-1 + FR-VP-004.
+- "When is the Original Order Record captured?" → **First activation of
+  either projection**, R-3 + FR-VP-005.
+- "Is the change event sync or async?" → **Sync**, R-8.
+- "Do we need any new runtime dep?" → **No**, R-5, R-6.
+
+## Out of scope for v1 (carried from spec Assumptions)
+
+- Multi-column sort.
+- Per-column custom comparators.
+- OR composition across different filters (per-column categorical OR
+  inside one popup is the only OR semantics in v1).
+- A user-exposed knob to invert filter/sort ordering.
+- Server-side rendering.

--- a/specs/002-003-row-visibility/research.md
+++ b/specs/002-003-row-visibility/research.md
@@ -27,6 +27,7 @@ assumed no sort. Without this rule, every downstream consumer
 (`005`, `008`, `009`, `010`) would have to invent its own answer.
 
 **Alternatives considered**:
+
 - *Sort-then-filter*: equivalent for predicate-only filters (filter is
   position-independent), but the rendered DOM differs because dimmed
   rows would have to move. Rejected — violates SC-005 (byte-identical
@@ -50,6 +51,7 @@ a single attribute + class removal pass. Also makes the FR-VP-004 rule
 ("sort only un-dimmed rows") trivially expressible.
 
 **Alternatives considered**:
+
 - *`display: none`*: shorter CSS but breaks SC-005 (the row's box is
   gone) and screen-reader announcement (`003` FR-022 forbids it).
   Rejected.
@@ -74,6 +76,7 @@ first sort, `003-filter` captured on first filter. The combined spec
 first, because either projection can be the user's first action.
 
 **Alternatives considered**:
+
 - *Capture at table-process time*: simpler, but mutates the OOR scope
   (every table on the page pays the snapshot cost, even those never
   enriched). Rejected — violates progressive enhancement.
@@ -108,6 +111,7 @@ means slider persistence and view-state persistence evolve independently
 per-table.
 
 **Alternatives considered**:
+
 - *Reuse `gs.s`*: would tangle two unrelated state shapes in one codec.
   Rejected.
 - *Per-table fragment key (`gs.v.<id>=...`)*: blows up the parameter
@@ -129,6 +133,7 @@ spec (US6 acceptance + FR-VP-007 prose).
 ## R-5 — Sort: stable, locale-aware, type-routed
 
 **Decision**:
+
 - Use `Array.prototype.sort` (stable since ES2019 across every evergreen
   engine within the constitution's 2-year floor).
 - For numeric columns (typed via the existing `core/type-detection.ts`):
@@ -148,6 +153,7 @@ collapses naturally because the column-type detector already picks one
 type per column.
 
 **Alternatives considered**:
+
 - *Hand-rolled comparators per column*: more code, more bugs, no win
   over `Intl.Collator`. Rejected.
 - *Adding a tiny dep like `natural-orderby`*: violates constitution §I
@@ -163,6 +169,7 @@ type per column.
 **passes** the filter, i.e. is NOT dimmed). The Active Filter Set is an
 array of predicates composed with logical AND. Two built-in predicate
 factories:
+
 - `numericRange({ min?, max?, hideEmpty? })` — open bounds allowed;
   empty cells dimmed only if `hideEmpty` is `true` (per `003` US1 +
   per-popup toggle).
@@ -179,6 +186,7 @@ predicate as a function means custom filters (none planned for v1, but
 called out as an extension point) plug in without changing the pipeline.
 
 **Alternatives considered**:
+
 - *Object-based DSL (`{ op: 'between', min, max }`)*: more verbose for
   no gain — the pipeline never introspects the predicate, only the URL
   codec does, and it reads from `toDirective()`. Rejected.
@@ -234,6 +242,7 @@ user-initiated event (`click`, `input`, popstate). Microtasks /
 hazards if the listener mutates a sibling enrichment's state.
 
 **Alternatives considered**:
+
 - *`requestAnimationFrame` batching inside the pipeline*: would
   guarantee one frame of latency. Rejected — listeners that need to
   batch can wrap their handler themselves.
@@ -257,6 +266,7 @@ pipeline computes synchronously from in-memory state, there is no
 async barrier between parse and render.
 
 **Alternatives considered**:
+
 - *Apply via `DOMContentLoaded` listener after first paint*: produces
   a visible flicker on slow devices. Rejected.
 - *Pre-render server-side*: not applicable — Grid-Sight is a
@@ -276,6 +286,7 @@ Centralising prevents the situation where every downstream consumer
 reads `tbody.rows` directly and rediscovers the sort-over-filter rule.
 
 **Alternatives considered**:
+
 - *Document the rules and let each consumer reimplement*: would have
   made this combined spec unnecessary. Rejected by the spec's own
   framing.
@@ -285,6 +296,7 @@ reads `tbody.rows` directly and rediscovers the sort-over-filter rule.
 ## R-11 — Accessibility wiring
 
 **Decision**: Unchanged from the source specs.
+
 - Sort lozenge:
   - `aria-sort` on the column header reflects `"ascending"`,
     `"descending"`, or `"none"`.
@@ -311,6 +323,7 @@ to survive the combination.
 
 **Decision**: Disabling Grid-Sight (`gridSight.disable()` or removing
 the toggle) runs the pipeline's `teardown(table)` which:
+
 1. Restores `tbody` row order to the OOR if any change was applied.
 2. Removes `data-gs-dimmed` and `gs-row--dimmed` from every row.
 3. Removes `aria-sort` from every header cell touched.

--- a/specs/002-003-row-visibility/tasks.md
+++ b/specs/002-003-row-visibility/tasks.md
@@ -278,6 +278,7 @@ Task: "Playwright e2e in tests/e2e/sort.spec.ts"
 ### Parallel-team strategy
 
 Once Phase 2 lands:
+
 - Worker A: US1 (sort) end-to-end.
 - Worker B: US2 (numeric filter) end-to-end.
 - Worker C: US3 (categorical filter) — starts after Worker B lands T023, otherwise rebases.

--- a/specs/002-003-row-visibility/tasks.md
+++ b/specs/002-003-row-visibility/tasks.md
@@ -1,0 +1,295 @@
+# Tasks: Row Visibility & Order (Sort + Filter)
+
+**Input**: Design documents from `/specs/002-003-row-visibility/`
+**Prerequisites**: plan.md ✓, spec.md ✓, research.md ✓, data-model.md ✓, contracts/ ✓ (`visible-rows-api.md`, `url-fragment-schema.md`), quickstart.md ✓
+
+**Tests**: Tests are **REQUIRED** — Constitution §II (Test Discipline) is a merge gate, and SC-006 explicitly mandates an automated parity check between pipeline output and rendered DOM. Every user story below includes Vitest unit tests, Storybook interaction tests for UI surfaces, and Playwright e2e for the golden flows.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing. Per the plan's "Implementation Streaming" section: the visible-row pipeline lands first as a thin identity-projection scaffold (Phase 2); then sort (US1) and the two filter variants (US2/US3) can proceed in parallel; the compose/chip (US4) and sort-over-filter semantics (US5) close out the combination; URL persistence (US6) ships as a single PR covering both directive shapes.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Maps to spec user stories US1–US6
+- Every task includes the exact file path
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the existing project scaffolding is ready; no new tooling needed (no new runtime deps, no new build steps).
+
+- [ ] T001 Verify `yarn install` succeeds and `yarn build` passes baseline at repo root (sanity baseline before any feature delta)
+- [ ] T002 [P] Record baseline bundle size from `scripts/bundle-size.js` into `specs/002-003-row-visibility/research.md` under R-7 (single sentence, gz number only) so each subsequent PR can be measured against it
+- [ ] T003 [P] Add the lozenge glyphs to the shared style sheet at `src/style.css` — `↕` sort lozenge class `gs-lozenge--sort`, `▽` filter lozenge class `gs-lozenge--filter`, plus the `gs-row--dimmed` opacity rule (CSS only; no JS wiring yet)
+
+**Checkpoint**: Baseline build green, lozenge glyphs available, bundle baseline recorded.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Land the **Visible Row Sequence pipeline as a thin identity-projection scaffold** with the public API frozen. After this phase, US1–US6 can plug in by calling `setSort` / `setFilter` without changing the pipeline shape.
+
+**⚠️ CRITICAL**: No user-story work begins until Phase 2 is complete. The pipeline scaffold MUST land with the contract in `contracts/visible-rows-api.md` frozen — every later phase consumes it.
+
+- [ ] T004 [P] Create the Original Order Record helper at `src/utils/original-order.ts` exporting `captureOnce(table)`, `getRecord(table)`, and `clearRecord(table)` backed by a module-scoped `WeakMap<HTMLTableElement, readonly HTMLTableRowElement[]>` (per data-model.md → OOR)
+- [ ] T005 [P] Create the visible-rows pipeline at `src/utils/visible-rows.ts` exporting the surface in `contracts/visible-rows-api.md` (`getVisibleRows`, `onVisibleRowsChange`, `setSort`, `setFilter`, `clearFilters`, `teardown`) plus the `VisibleRowEntry` / `VisibleRowSequence` / `SortDirective` / `FilterPredicate` / `FilterDirective` types — for this task it returns the **identity projection** (no sort, all rows un-dimmed) and the `mergeByOriginalIndex` body is a stub that just returns the visible-rows-in-OOR-order; synchronous emission and `revision` counter MUST be live from day one
+- [ ] T006 [US1] [US2] [US3] Extend `src/ui/header-utils.ts` to register two new lozenge slots in `LozengeSpec` (`id: 'sort'` and `id: 'filter'`), wired to no-op handlers for now; this guarantees the lozenge cluster reserves space + a11y order so US1–US3 only need to fill in the click + popup logic
+- [ ] T007 [P] Vitest scaffold at `src/utils/__tests__/original-order.test.ts` covering: capture-once semantics, capture survives if `tbody.rows` mutates afterwards, `clearRecord` removes the entry
+- [ ] T008 [P] Vitest scaffold at `src/utils/__tests__/visible-rows.test.ts` covering: identity projection on a fresh table, listener fires synchronously on `setSort(null)` is a no-op (no event), `revision` increments monotonically, `getVisibleRows` returns the cached sequence (reference-equal between events), `teardown` is idempotent
+- [ ] T009 Update `src/index.ts` to import `teardown` from `src/utils/visible-rows.ts` and call it for every table during the existing `disable()` loop (placed before `removePlusIcons(table)`); also add a Vitest snapshot in `src/__tests__/disable-snapshot.test.ts` that asserts `tbody.innerHTML` byte-identical before init vs after disable on a table that had sort + filter applied (satisfies SC-005 once US1/US2 land — for now the snapshot covers the identity case)
+
+**Checkpoint**: Pipeline scaffold green; identity projection passes; lozenge slots reserved in header-utils; teardown wired into `disable()`. US1/US2/US3 can now proceed in parallel.
+
+---
+
+## Phase 3: User Story 1 — Sort a column ascending / descending / off (Priority: P1) 🎯 MVP
+
+**Goal**: A user clicks the **↕** sort lozenge on any sortable column and gets a three-state asc → desc → original cycle. Only one column drives sort at a time. The sort runs through the pipeline established in Phase 2.
+
+**Independent Test**: Click the sort lozenge on a numeric column three times and verify asc → desc → original. Repeat on a categorical column. `aria-sort` reflects state at every step. Sort completes in < 100 ms on a 1 000-row table (SC-002).
+
+### Tests for User Story 1
+
+- [ ] T010 [P] [US1] Vitest unit test at `src/enrichments/__tests__/sort.test.ts` covering the three-state cycle, single-column-at-a-time invariant (clicking column B while column A is sorted clears A), numeric comparator on `cleanNumericCell` output with `NaN` → end-of-list in both directions, locale-aware categorical comparator via shared `Intl.Collator`, tie stability via Array.sort
+- [ ] T011 [P] [US1] Storybook interaction test at `src/ui/__tests__/sort-lozenge.test.ts` (uses `@storybook/addon-vitest`) covering: lozenge renders ↕, `aria-sort="none|ascending|descending"` toggles correctly, accessible name reflects the **next** action ("Sort Amount descending"), keyboard activation via Enter/Space
+- [ ] T012 [US1] Playwright e2e at `tests/e2e/sort.spec.ts` exercising the full three-state cycle on the demo page (numeric column then categorical column), asserting render order via `tbody tr` text comparison
+
+### Implementation for User Story 1
+
+- [ ] T013 [P] [US1] Create the sort comparator at `src/enrichments/sort.ts` exporting `makeComparator(column, direction, columnType)` that returns a `(a: HTMLTableRowElement, b: HTMLTableRowElement) => number` using `cleanNumericCell` for numeric columns (NaN → +∞) and a module-level shared `Intl.Collator(undefined, { sensitivity: 'base', numeric: true })` for categorical
+- [ ] T014 [P] [US1] Create the sort lozenge button factory at `src/ui/sort-lozenge.ts` exporting `createSortLozenge({ columnIndex, columnKey, columnType, getCurrentSort, onChange })` that returns the `<button>` element, owns the three-state click handler, and updates the column header's `aria-sort` attribute
+- [ ] T015 [US1] Wire sort into the pipeline in `src/utils/visible-rows.ts`: replace the Phase-2 stub `mergeByOriginalIndex` with the real implementation per data-model.md (visible rows in sort order, dimmed rows anchor at their OOR positions). When `state.sort` is null, the path remains identity-with-dim-anchors. Also update `aria-sort` on the sort column header inside the same re-evaluation
+- [ ] T016 [US1] Register the sort lozenge in `src/ui/header-utils.ts` by replacing the no-op handler from T006 with the real factory from T014, passing `setSort` from `visible-rows.ts` as the `onChange` callback; honour `data-gs-no-sort` and the `rowspan`/`colspan` body-cell suppression rule on the affected column (existing column-type detector + a small new check)
+- [ ] T017 [US1] Add the `columnKey` derivation helper at `src/utils/view-state-url.ts` (just `colKey(header, columnIndex)` per `contracts/url-fragment-schema.md` "Column-key derivation"; rest of the codec lands in US6) so sort can populate `SortDirective.columnKey` correctly from day one — this avoids a later refactor when US6 adds persistence
+
+**Checkpoint**: Sort works end-to-end on any sortable column, three-state cycle behaves, `aria-sort` correct, < 100 ms on 1 000 rows, byte-identical disable still holds.
+
+---
+
+## Phase 4: User Story 2 — Filter a numeric column by range (Priority: P1)
+
+**Goal**: Click the **▽** filter lozenge on a numeric column; a popup with Min/Max number inputs appears; out-of-range rows are dimmed (not removed). Popup closes on outside click or Escape; filter state survives the close. Per-popup "Hide empty cells" toggle.
+
+**Independent Test**: Open the numeric filter on a numeric column, set `Min=100, Max=500`, close the popup, observe rows outside the range dimmed via `data-gs-dimmed="true"` + `gs-row--dimmed` class, rows still in DOM, screen reader still announces them.
+
+### Tests for User Story 2
+
+- [ ] T018 [P] [US2] Vitest unit test at `src/enrichments/__tests__/filter.test.ts` (numeric portion) covering the `numericRange({ min, max, hideEmpty })` predicate factory: closed range, open-min, open-max, fully open, hideEmpty true/false on blank cells, `toDirective()` round-trip shape
+- [ ] T019 [P] [US2] Storybook interaction test at `src/ui/__tests__/filter-popup-numeric.test.ts` covering: opens on lozenge click, Min/Max inputs accept numbers, "Hide empty cells" checkbox toggles, closes on outside click and on Escape, focus trap inside the popup, focus returns to the lozenge on close, `aria-pressed` on the lozenge reflects predicate-active state
+- [ ] T020 [US2] Playwright e2e at `tests/e2e/filter.spec.ts` (numeric scenario only — categorical scenario added in US3) exercising US2 AS-1..AS-4
+
+### Implementation for User Story 2
+
+- [ ] T021 [P] [US2] Create the filter predicate factories at `src/enrichments/filter.ts` exporting `numericRange({ columnIndex, columnKey, min, max, hideEmpty })` returning a `FilterPredicate` whose `test(row)` reads the column cell via `cleanNumericCell` and applies the range with `hideEmpty` semantics, and whose `toDirective()` returns the `kind: 'numeric-range'` shape from data-model.md
+- [ ] T022 [P] [US2] Create the numeric filter popup at `src/ui/filter-popup-numeric.ts` exporting `openNumericFilterPopup({ anchorEl, columnIndex, columnKey, current, onApply, onClose })` — owns input rendering, focus-trap, Escape handler, outside-click close, and emits `onApply(predicate | null)` (null clears the filter)
+- [ ] T023 [P] [US2] Create the filter lozenge button factory at `src/ui/filter-lozenge.ts` exporting `createFilterLozenge({ columnIndex, columnKey, columnType, getCurrentFilter, onOpenPopup })` — type-aware (it knows whether to open the numeric or categorical popup; categorical wiring lands in US3 but the lozenge factory ships once here) and maintains `aria-pressed`
+- [ ] T024 [US2] Register the filter lozenge in `src/ui/header-utils.ts` by replacing the no-op handler from T006 with the real factory from T023; the lozenge dispatches to the numeric popup for `numeric` columns; categorical branch is a no-op stub until US3 (`throw new Error('not yet')` would break US3 in flight, so emit a console.warn and return instead). Honour `data-gs-no-filter` and the `rowspan`/`colspan` suppression rule
+
+**Checkpoint**: Numeric filter works end-to-end; dimming behaves per spec; popup a11y contract honoured; `aria-pressed` correct.
+
+---
+
+## Phase 5: User Story 3 — Filter a categorical column by value list (Priority: P1)
+
+**Goal**: The filter lozenge on a categorical column opens a popup with a count-labelled checkbox list, "Select all" / "Select none", and a type-to-search input. Per-popup "Hide empty cells" toggle.
+
+**Independent Test**: Open the categorical filter on a categorical column, type to narrow the visible checkbox list, uncheck two values, close the popup, observe rows whose cell value is in the unchecked set are dimmed.
+
+### Tests for User Story 3
+
+- [ ] T025 [P] [US3] Vitest unit test at `src/enrichments/__tests__/filter.test.ts` (extend the file from T018 — add a `describe('categorical')` block) covering `categoricalInclusion({ allowed: Set<string>, hideEmpty })` predicate, `toDirective()` `kind: 'categorical'` shape, empty-string membership ruled by `hideEmpty`
+- [ ] T026 [P] [US3] Storybook interaction test at `src/ui/__tests__/filter-popup-categorical.test.ts` covering: checkbox list renders with per-value counts, search input narrows the visible list only (does NOT modify the predicate until apply), Select all / Select none affordances, focus trap + Escape close, focus return, `aria-pressed` on lozenge
+- [ ] T027 [US3] Extend the Playwright e2e at `tests/e2e/filter.spec.ts` with a categorical scenario (US3 AS-1..AS-3) — same file as T020 since they share the spec but exercise different popups
+
+### Implementation for User Story 3
+
+- [ ] T028 [P] [US3] Extend `src/enrichments/filter.ts` with the `categoricalInclusion({ columnIndex, columnKey, allowed, hideEmpty })` factory returning a `FilterPredicate` whose `test(row)` reads the column cell's `textContent.trim()` and checks Set membership; provide a helper `collectCategoricalValues(table, columnIndex): Map<string, number>` (value → count) used by the popup
+- [ ] T029 [P] [US3] Create the categorical filter popup at `src/ui/filter-popup-categorical.ts` exporting `openCategoricalFilterPopup({ anchorEl, columnIndex, columnKey, current, valueCounts, onApply, onClose })` — count-labelled checkbox list, type-to-search input, Select-all / Select-none buttons, focus-trap, Escape + outside-click close
+- [ ] T030 [US3] Replace the categorical-branch console.warn stub from T024 in `src/ui/header-utils.ts` (or `src/ui/filter-lozenge.ts`, wherever the dispatch lives after T023) with the real `openCategoricalFilterPopup` call
+
+**Checkpoint**: Both filter variants work end-to-end. AND-composition across columns works for free because the pipeline holds a `Map<columnIndex, FilterPredicate>` from Phase 2.
+
+---
+
+## Phase 6: User Story 4 — Compose filters across columns + clear-all chip (Priority: P2)
+
+**Goal**: Multi-column filters compose with logical AND (already supported by the pipeline from Phase 2). A summary chip lists every active filter as `Column: predicate` with a **Clear all filters** button. Zero-match filter shows an empty-state message.
+
+**Independent Test**: Apply a numeric filter on column A and a categorical filter on column B → only rows passing BOTH are un-dimmed. Chip lists both filters; clicking each filter's "×" clears that one; Clear-all clears all and removes the chip. Apply a filter that matches zero rows → empty-state message appears (still in same DOM, not replacing tbody).
+
+### Tests for User Story 4
+
+- [ ] T031 [P] [US4] Vitest unit test at `src/utils/__tests__/visible-rows.test.ts` (extend) covering AND composition across two predicates: row dimmed if any predicate returns false; clearing one predicate restores rows that only that predicate dimmed
+- [ ] T032 [P] [US4] Storybook interaction test at `src/ui/__tests__/filter-chip.test.ts` covering: chip renders with one entry per active filter, per-filter remove button restores that column's rows, "Clear all filters" button removes every filter and the chip itself, chip is keyboard-reachable (Tab order), empty-state message renders when `entries.every(e => e.dimmed)`
+- [ ] T033 [US4] Playwright e2e at `tests/e2e/filter.spec.ts` (extend) with: apply two filters → chip lists both; remove via chip; click Clear all; zero-match empty-state
+
+### Implementation for User Story 4
+
+- [ ] T034 [US4] Create the filter chip at `src/enrichments/filter-chip.ts` exporting `mountFilterChip(table)` / `unmountFilterChip(table)` — subscribes to `onVisibleRowsChange`, renders a chip element listing each entry from `seq.filters` as `Column: predicate-summary` with a per-filter remove button, plus a "Clear all filters" button that calls `clearFilters(table)`; the chip element is appended **after** the table inside a `gs-filter-chip-container` div; when `seq.filters.size === 0` the chip is removed
+- [ ] T035 [US4] Add the zero-match empty-state inside `mountFilterChip` (same file as T034): when `seq.entries.every(e => e.dimmed)` and at least one filter is active, render a "No rows match the current filters." message in the chip container; remove on the next emission that has any un-dimmed row
+- [ ] T036 [US4] Wire `mountFilterChip` into `processTable` in `src/core/table-processor.ts` (or, if that file is too downstream, into `src/index.ts` `processTable`) so every Grid-Sight-enabled table gets a chip subscription; `unmountFilterChip` is called from the pipeline's `teardown(table)` (T005) — add the call there now
+
+**Checkpoint**: Multi-filter AND composition + chip + empty state behave per spec. US1, US2, US3, US4 all green together.
+
+---
+
+## Phase 7: User Story 5 — Sort over a filtered view (Priority: P2, new combination semantics)
+
+**Goal**: With a filter active and a sort then applied, the sort orders only the un-dimmed rows; dimmed rows remain anchored at their original positions (per `mergeByOriginalIndex` rule in data-model.md). Clearing the filter shows all rows in sort order. Clearing the sort restores original document order **within** the un-dimmed set; the filter dimming is unchanged.
+
+**Independent Test**: Apply a numeric filter that dims half the rows, then sort the same column descending. Verify: (a) dimmed rows do not move into the un-dimmed block, (b) the un-dimmed rows are in descending order, (c) clearing the filter shows every row in descending order with no extra click, (d) clearing the sort but keeping the filter restores original document order within the un-dimmed set.
+
+> **Note**: The `mergeByOriginalIndex` algorithm itself was implemented in T015 as part of US1. This phase **verifies** that implementation against the US5 acceptance scenarios and adds the explicit coverage. If T015's algorithm is wrong, this phase fixes it.
+
+### Tests for User Story 5
+
+- [ ] T037 [P] [US5] Vitest unit test at `src/utils/__tests__/visible-rows.test.ts` (extend) covering US5 AS-1..AS-3: filter then sort → dimmed rows at original positions, visible rows descending; sort then clear filter → all rows descending; sort + filter both active → clearing sort restores original order within un-dimmed block while dim flags are unchanged
+- [ ] T038 [P] [US5] Storybook interaction test at `src/utils/__tests__/visible-rows-parity.test.ts` for SC-006: after every combination of sort + filter changes on a fixture table, assert `getVisibleRows(table).entries` matches `Array.from(table.tBodies[0].rows)` 1:1 in both order and `dimmed` flag (parity between pipeline output and rendered DOM)
+- [ ] T039 [US5] Playwright e2e at `tests/e2e/sort-over-filter.spec.ts` exercising the full US5 golden flow on the demo page (filter Amount 100–500, then sort Amount desc, then clear filter, then clear sort with filter re-applied)
+
+### Implementation for User Story 5
+
+- [ ] T040 [US5] Verify and, if needed, fix the `mergeByOriginalIndex` body in `src/utils/visible-rows.ts` against US5 AS-1 — specifically the "dimmed rows act as anchors; visible rows slot in between them in sort order" rule from data-model.md. The implementation from T015 should already do this; this task is the formal check + any micro-fix the unit test from T037 surfaces
+- [ ] T041 [US5] Add the "Restore order" rule from spec Edge Cases: when both sort and filter are toggled off, the pipeline restores `tbody` to the OOR exactly. Confirm by extending the Vitest test at `src/utils/__tests__/visible-rows.test.ts` (no new file needed) with a "both off → tbody.innerHTML byte-equal to pre-init" assertion
+
+**Checkpoint**: SC-006 parity check passes. US5 golden flow green in Playwright. The four MVP user stories (US1–US4) + US5 combination semantics all work.
+
+---
+
+## Phase 8: User Story 6 — Persist and share the combined view via URL (Priority: P2)
+
+**Goal**: Both sort and filter state are encoded under one URL-fragment namespace (`gs.v`) per page, restored before content settles, and reproduce 100% on another machine with no `localStorage` dependency. Missing-target directives are silently dropped. Filters applied before sort on load (FR-VP-007).
+
+**Independent Test**: Apply sort + multi-column filter to a table, copy the URL, open in a fresh browser profile → identical view with no visible flash beyond one animation frame. Hand-edit the URL to reference a non-existent column → page loads with surviving directives applied; missing one silently dropped.
+
+### Tests for User Story 6
+
+- [ ] T042 [P] [US6] Vitest unit test at `src/utils/__tests__/view-state-url.test.ts` covering the full codec round-trip per `contracts/url-fragment-schema.md`: encode → decode → equal for every worked example, lenient decode of malformed directives (returns the rest), missing-column drop, empty-state codec yields no parameter, `gs.s` and `gs.v` coexist without clobbering each other
+- [ ] T043 [P] [US6] Vitest unit test at `src/utils/__tests__/view-state-url.test.ts` (same file, separate describe) covering load-order: parser applies filters before sort, so a sort-over-filter URL round-trips identically through the live pipeline
+- [ ] T044 [US6] Playwright e2e at `tests/e2e/view-state-url.spec.ts` covering SC-003 + SC-004: open page → apply sort + filter → copy URL → open in a fresh context (Playwright `browser.newContext()`) → assert (i) identical visible-rows entries, (ii) no flash (the first paint already reflects the restored state, measured via screenshot diff against the post-paint frame)
+
+### Implementation for User Story 6
+
+- [ ] T045 [P] [US6] Implement the full codec at `src/utils/view-state-url.ts` per `contracts/url-fragment-schema.md`: `encodeViewState(perTable)` → fragment payload, `decodeViewState(rawHash)` → `{ tableId, sort?, filters: FilterDirective[] }[]`, plus the `gs.v` fragment-parameter read/write helpers that preserve other parameters (mirrors the `slider-persistence.ts` write-other-preserved approach but does NOT share code). T017 already added the `colKey` helper here; extend, don't replace
+- [ ] T046 [US6] Add a serialise / hydrate pair on the visible-rows pipeline at `src/utils/visible-rows.ts`: `serialiseTable(table): TableViewDirective | null` (reads current state to a directive) and `hydrateTable(table, directive)` (applies filters then sort in that order per FR-VP-007 by calling the existing `setFilter` / `setSort` paths) — these are the codec's only contact points with the pipeline
+- [ ] T047 [US6] Wire URL restore into `src/index.ts` `init()`: read `location.hash` synchronously, parse via `decodeViewState`, for each entry whose table exists call `hydrateTable(table, entry)` **before** the lozenge cluster mounts (so the first paint reflects the restored projection — satisfies SC-003)
+- [ ] T048 [US6] Wire URL save: subscribe in `src/index.ts` (or a small new module `src/utils/view-state-url-sync.ts` if `index.ts` grows uncomfortable) to `onVisibleRowsChange` for every processed table; on every emission, recompute the combined `gs.v` payload across all tables via `encodeViewState` and `history.replaceState` to update `location.hash` without polluting browser history (mirrors `slider-persistence.ts` `replaceState` pattern)
+- [ ] T049 [US6] Implement the "missing target silently dropped" rule inside `hydrateTable`: if a directive references a column key that does not slug to any current column header, the predicate / sort is dropped, the rest is applied, and no exception is thrown (matches the spec's US6 acceptance + FR-VP-006 prose)
+
+**Checkpoint**: Full feature complete. URL round-trip works across browser profiles. SC-001..SC-006 all measurable and passing.
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Purpose**: Verify constitution gates, finalise docs, measure bundle delta against the R-7 budget.
+
+- [ ] T050 [P] Run `yarn build` and verify `scripts/bundle-size.js` reports a delta of **≤ 2.0 KB gzipped** vs the baseline recorded in T002. If breached, file a budget note in `tasks.md` and either trim or escalate per Constitution §I
+- [ ] T051 [P] Accessibility audit: run the Storybook a11y addon over every new story (sort lozenge, both filter popups, chip) and fix any violation. Cross-check the four Constitution §III hard minimums (keyboard-operable, ARIA roles/names/states, non-colour cue, AT announcement of dimmed rows)
+- [ ] T052 [P] Update `README.md` if the public surface changes (per the contract, no new `window.gridSight.*` is exposed in v1 — but mention sort + filter in the feature list)
+- [ ] T053 Run `yarn test` (Vitest unit + Storybook) and `yarn test:e2e` (Playwright) — both green is the merge gate per Constitution §II
+- [ ] T054 Run the quickstart manual smoke test from `specs/002-003-row-visibility/quickstart.md` "Manual smoke test" section end-to-end on a built demo page and confirm each of the five steps behaves as described
+- [ ] T055 Verify SC-002 (1 000-row sort+filter < 100 ms on a mid-range laptop) by running the Playwright e2e on a generated 1 000-row fixture and asserting the time from click to settled DOM is < 100 ms; add the fixture under `tests/e2e/fixtures/thousand-rows.html` and the perf assertion as part of `tests/e2e/sort-over-filter.spec.ts` (extension, not a new file)
+
+**Checkpoint**: Feature ready to merge. All SCs covered.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase dependencies
+
+- **Phase 1 (Setup)**: No deps; run immediately.
+- **Phase 2 (Foundational)**: Depends on Phase 1. **BLOCKS all user stories.** The pipeline scaffold + lozenge slots + OOR helper must land first.
+- **Phase 3 (US1 — Sort)**: Depends on Phase 2.
+- **Phase 4 (US2 — Numeric Filter)**: Depends on Phase 2. **Independent of US1** (different files, different lozenge).
+- **Phase 5 (US3 — Categorical Filter)**: Depends on Phase 4 (T023 ships the shared filter lozenge factory). Could be parallelised by splitting T023, but cleaner to land US2 first.
+- **Phase 6 (US4 — Chip + Compose)**: Depends on Phase 4 (needs at least one filter to exist for the chip to be meaningful). US3 also recommended before US4 so the chip is exercised against both predicate kinds.
+- **Phase 7 (US5 — Sort over Filter)**: Depends on Phase 3 (US1) AND Phase 4 (US2). The `mergeByOriginalIndex` algorithm landed in T015 (US1); this phase verifies it works once filter is real.
+- **Phase 8 (US6 — URL persistence)**: Depends on Phase 3, 4, 5, 6 (needs sort + both filter variants + chip to round-trip). Can begin in parallel with Phase 7 since their files don't overlap.
+- **Phase 9 (Polish)**: Depends on all user stories landed.
+
+### User-story dependencies
+
+- **US1 (P1, sort)**: Foundation only.
+- **US2 (P1, numeric filter)**: Foundation only.
+- **US3 (P1, categorical filter)**: US2 (shared lozenge factory).
+- **US4 (P2, chip + compose)**: US2 + US3 (chip exercises both).
+- **US5 (P2, sort-over-filter)**: US1 + US2.
+- **US6 (P2, URL persistence)**: US1 + US2 + US3 + US4 (encodes all of them).
+
+### Within each story
+
+- Tests are written **before** implementation per Constitution §II (the gate is "tests green at merge", but the project's TDD-leaning style writes them first).
+- Pipeline-shape changes land in `visible-rows.ts` only via the writers (`sort.ts`, `filter.ts`); UI lives in `src/ui/`.
+- Wire-up to `header-utils.ts` is the **last step** in each story so partial work never injects a half-working lozenge.
+
+### Parallel opportunities
+
+- **Setup**: T002 and T003 are independent of T001.
+- **Foundation**: T004, T005, T007, T008 can all run in parallel (different files); T006 follows T005; T009 follows T005.
+- **Within US1**: T010, T011, T013, T014 are all parallel (different files). T015 / T016 / T017 are sequential against the pipeline.
+- **Within US2**: T018, T019, T021, T022, T023 are parallel; T024 is the final wire-up.
+- **Across stories**: Once Foundation lands, US1 + US2 can be developed by two workers concurrently (no shared file, only `header-utils.ts` which uses guarded slot registration from T006).
+
+---
+
+## Parallel example: User Story 1 (Sort)
+
+```bash
+# Tests-first batch (all parallel — different files):
+Task: "Vitest unit test for sort comparator + three-state cycle in src/enrichments/__tests__/sort.test.ts"
+Task: "Storybook interaction test for sort lozenge in src/ui/__tests__/sort-lozenge.test.ts"
+
+# Implementation batch 1 (all parallel — different files):
+Task: "Sort comparator in src/enrichments/sort.ts"
+Task: "Sort lozenge factory in src/ui/sort-lozenge.ts"
+Task: "colKey helper in src/utils/view-state-url.ts"
+
+# Sequential tail:
+Task: "Wire sort into pipeline (mergeByOriginalIndex) in src/utils/visible-rows.ts"
+Task: "Register sort lozenge in src/ui/header-utils.ts"
+Task: "Playwright e2e in tests/e2e/sort.spec.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP first — US1 only
+
+1. Phase 1 (Setup) → baseline green.
+2. Phase 2 (Foundational pipeline + OOR + lozenge slots).
+3. Phase 3 (US1 — Sort).
+4. **STOP and VALIDATE**: ship a demo page that sorts; constitution gates green.
+
+### Incremental delivery
+
+1. Foundation + US1 → MVP (sort works).
+2. Add US2 → numeric filter works.
+3. Add US3 → categorical filter works.
+4. Add US4 → compose + chip; SC-001 measurable in three interactions.
+5. Add US5 → sort-over-filter; SC-006 parity check passes.
+6. Add US6 → shareable URL; SC-003 + SC-004 pass.
+7. Polish → SC-002 perf budget, SC-005 byte-identical, bundle ≤ 2 KB delta.
+
+### Parallel-team strategy
+
+Once Phase 2 lands:
+- Worker A: US1 (sort) end-to-end.
+- Worker B: US2 (numeric filter) end-to-end.
+- Worker C: US3 (categorical filter) — starts after Worker B lands T023, otherwise rebases.
+- Worker D: US6 (URL codec) — can begin alongside US2/3 because the codec is unit-testable against fabricated directives; integration with `init()` waits for US1+US4.
+
+---
+
+## Notes
+
+- `[P]` tasks operate on different files with no incomplete-task dependencies; safe to dispatch in parallel.
+- Every story's wire-up to `header-utils.ts` is the final step in that story; this keeps partial work from injecting a half-working lozenge.
+- The contract in `contracts/visible-rows-api.md` is frozen as of Phase 2 — later phases extend behaviour but MUST NOT change exported shapes (Development-Phase Posture grants escape hatches but the bar is "PR that updates every downstream consumer in the same commit").
+- Commit cadence: at the very least, one commit per phase checkpoint. Within a phase, batch related parallel tasks into a single commit where convenient.
+- Tests run in CI on every PR; merging without `yarn test` and `yarn test:e2e` green is a Constitution §II violation.
+- Bundle-size measurement runs on every PR via `scripts/bundle-size.js`; the R-7 budget is ≤ 2.0 KB gzipped net delta.


### PR DESCRIPTION
## Summary

This PR adds the complete specification and planning documentation for the Row Visibility & Order feature (combining sort and filter functionality). This is a documentation-only change that establishes the design, data model, implementation plan, and contracts for the feature before development begins.

## Changes

- **spec.md**: Complete feature specification covering user stories (US1–US6), functional requirements (FR-VP-001 through FR-VP-007), success criteria (SC-001 through SC-006), and acceptance scenarios for sort, filter (numeric and categorical), composition, and URL persistence
- **research.md**: Design decisions and rationale for 9 key architectural choices (R-1 through R-9), including pipeline ordering (filter-then-sort), dim-not-hide approach, Original Order Record capture semantics, URL fragment schema, sort algorithm, filter predicates, bundle budget, change event semantics, and restore-before-paint behavior
- **plan.md**: Implementation roadmap with technical context, constitution compliance checklist, and streaming implementation strategy (pipeline scaffold first, then sort/filter in parallel, then composition and URL persistence)
- **data-model.md**: In-memory data shapes (`VisibleRowEntry`, `VisibleRowSequence`, `SortDirective`, `FilterPredicate`, `OriginalOrderRecord`, `PipelineState`) and computed re-evaluation flow with `mergeByOriginalIndex` semantics
- **tasks.md**: Detailed task breakdown across 9 phases (setup, foundational pipeline, sort, numeric filter, categorical filter, composition, URL persistence, performance, and polish) with test requirements and acceptance criteria
- **quickstart.md**: Quick reference guide for downstream consumers (specs 005, 008, 009, 010) on how to read from the visible-rows pipeline
- **contracts/visible-rows-api.md**: Frozen public API contract for `utils/visible-rows.ts` with type definitions and behavior guarantees
- **contracts/url-fragment-schema.md**: URL fragment grammar and serialization rules for the `gs.v` parameter (separate from `gs.s` sliders)
- **checklists/requirements.md**: Specification quality validation checklist

## Notable Details

- **Zero new runtime dependencies**: Uses only `Array.prototype.sort` (stable since ES2019), `Intl.Collator`, and standard DOM APIs
- **Bundle budget**: 2.0 KB gzipped net delta for the combined feature (measured per PR via `scripts/bundle-size.js`)
- **Byte-identical restore**: Original Order Record ensures `teardown()` restores DOM to pre-init state without leftover attributes or classes
- **Synchronous change events**: Pipeline emits listener callbacks synchronously so downstream enrichments re-render within the same animation frame
- **Filter-then-sort pipeline**: Dimmed rows anchor at original positions; visible rows fill gaps in sort order (settles US5 precisely)
- **Per-table URL directive**: Single `gs.v` parameter holds comma-separated table directives, separate from `gs.s` (sliders)

This documentation is the gate for Phase 2 (foundational pipeline implementation) and enables parallel work on sort, numeric filter, and categorical filter in Phase 3–4.

https://claude.ai/code/session_01PTmQ8TF6KsuKeaK6yZSFZm