### PR TITLE
feat(013): canonical table-grid addressing layer

### DIFF
--- a/specs/013-table-grid-addressing/tasks.md
+++ b/specs/013-table-grid-addressing/tasks.md
@@ -27,9 +27,9 @@ mandates them.
 **Purpose**: Establish the module's import surface and the test harness all
 later phases depend on.
 
-- [ ] T001 Create `src/core/table-grid.ts` with the marker constants (`SCAFFOLD_ATTR='data-gs-injected'`, `VIRTUAL_COL_ATTR='data-gs-virtual-column'`) and exported, typed function stubs for the full surface in `contracts/table-grid-api.md` (throwing `NotImplemented` bodies) so consumers and tests can import against a stable signature.
-- [ ] T002 [P] Create test files `src/core/__tests__/table-grid.test.ts` and `src/core/__tests__/table-grid.composition.test.ts` with imports + top-level `describe` blocks (placeholder `it.todo`s).
-- [ ] T003 [P] Create shared test harness `src/core/__tests__/helpers/grid-fixture.ts`: builders for the canonical numeric grid (row headers + numeric body), a helper to capture each author cell's identity, and activation helpers — `enableRowSlider`, `enableColSlider`, `addCumulativeColumn`, `addSparklineColumn`, `applySort` — plus an `activateInOrder(steps, order)` utility that runs a set of activations in a chosen sequence (for both-permutation testing).
+- [X] T001 Create `src/core/table-grid.ts` with the marker constants (`SCAFFOLD_ATTR='data-gs-injected'`, `VIRTUAL_COL_ATTR='data-gs-virtual-column'`) and exported, typed function stubs for the full surface in `contracts/table-grid-api.md` (throwing `NotImplemented` bodies) so consumers and tests can import against a stable signature.
+- [X] T002 [P] Create test files `src/core/__tests__/table-grid.test.ts` and `src/core/__tests__/table-grid.composition.test.ts` with imports + top-level `describe` blocks (placeholder `it.todo`s).
+- [X] T003 [P] Create shared test harness `src/core/__tests__/helpers/grid-fixture.ts`: builders for the canonical numeric grid (row headers + numeric body), a helper to capture each author cell's identity, and activation helpers — `enableRowSlider`, `enableColSlider`, `addCumulativeColumn`, `addSparklineColumn`, `applySort` — plus an `activateInOrder(steps, order)` utility that runs a set of activations in a chosen sequence (for both-permutation testing).
 
 ---
 
@@ -38,11 +38,11 @@ later phases depend on.
 **Purpose**: The classification + row/cell/value primitives every user story
 builds on. **No user story can begin until this phase is complete.**
 
-- [ ] T004 Implement `isScaffold` and `isVirtualColumn` in `src/core/table-grid.ts` (attribute reads only).
-- [ ] T005 Implement row access `gridRows`, `headerRow`, `bodyRows` in `src/core/table-grid.ts` — exclude scaffold rows, exclude `<tfoot>` rows from the body set, keep dimmed rows; reuse the header-detection rule from `src/utils/original-order.ts::getDataRows` (do not duplicate it — import or mirror its logic with a reference comment). (depends on T004)
-- [ ] T006 Implement cell views `gridCells`, `sourceCells` and counts `sourceColumnCount`, `gridColumnCount` in `src/core/table-grid.ts` — `gridCells` = non-scaffold cells (source then virtual, DOM order); `sourceCells` = also excludes `data-gs-virtual-column`. (depends on T004)
-- [ ] T007 Implement `cellValue(cell)` in `src/core/table-grid.ts` — return the cell's text excluding Grid-Sight-injected UI (`.gs-lozenge-cluster`, `[data-gs-slider-readout]`, and other GS-owned descendants), trimmed; identity (`textContent.trim()`) for a clean cell. (Foundational because US1/US3/US4 all read values through it.)
-- [ ] T008 [P] Unit tests in `src/core/__tests__/table-grid.test.ts` for the foundational primitives: classification, `gridRows`/`headerRow`/`bodyRows` (incl. `<thead>` vs implicit-header, `<tfoot>` exclusion, dimmed-kept), `gridCells`/`sourceCells`/counts (incl. virtual ordering), and `cellValue` purity + identity. Assert INV-1/INV-4/INV-6/INV-8.
+- [X] T004 Implement `isScaffold` and `isVirtualColumn` in `src/core/table-grid.ts` (attribute reads only).
+- [X] T005 Implement row access `gridRows`, `headerRow`, `bodyRows` in `src/core/table-grid.ts` — exclude scaffold rows, exclude `<tfoot>` rows from the body set, keep dimmed rows; reuse the header-detection rule from `src/utils/original-order.ts::getDataRows` (do not duplicate it — import or mirror its logic with a reference comment). (depends on T004)
+- [X] T006 Implement cell views `gridCells`, `sourceCells` and counts `sourceColumnCount`, `gridColumnCount` in `src/core/table-grid.ts` — `gridCells` = non-scaffold cells (source then virtual, DOM order); `sourceCells` = also excludes `data-gs-virtual-column`. (depends on T004)
+- [X] T007 Implement `cellValue(cell)` in `src/core/table-grid.ts` — return the cell's text excluding Grid-Sight-injected UI (`.gs-lozenge-cluster`, `[data-gs-slider-readout]`, and other GS-owned descendants), trimmed; identity (`textContent.trim()`) for a clean cell. (Foundational because US1/US3/US4 all read values through it.)
+- [X] T008 [P] Unit tests in `src/core/__tests__/table-grid.test.ts` for the foundational primitives: classification, `gridRows`/`headerRow`/`bodyRows` (incl. `<thead>` vs implicit-header, `<tfoot>` exclusion, dimmed-kept), `gridCells`/`sourceCells`/counts (incl. virtual ordering), and `cellValue` purity + identity. Assert INV-1/INV-4/INV-6/INV-8.
 
 **Checkpoint**: Primitives implemented and unit-green; translation + consumers can begin.
 
@@ -59,17 +59,17 @@ source K and `headerCellFor(K)` is the author header.
 
 ### Tests for User Story 1 ⚠️ (write first, ensure they FAIL)
 
-- [ ] T009 [P] [US1] Unit tests in `src/core/__tests__/table-grid.test.ts` for `cellAt`, `columnCells`, `headerCellFor`, `logicalColIndexOf`: rowspan safety under a row slider (INV-2), virtual columns addressable after source columns, and out-of-range → `null`/`[]`/`-1` (INV-7). Use the harness from T003.
+- [X] T009 [P] [US1] Unit tests in `src/core/__tests__/table-grid.test.ts` for `cellAt`, `columnCells`, `headerCellFor`, `logicalColIndexOf`: rowspan safety under a row slider (INV-2), virtual columns addressable after source columns, and out-of-range → `null`/`[]`/`-1` (INV-7). Use the harness from T003.
 
 ### Implementation for User Story 1
 
-- [ ] T010 [US1] Implement `cellAt`, `columnCells` (rowspan-safe, per-row scaffold filtering), `headerCellFor` (author-colspan rule per research R-6), and `logicalColIndexOf` in `src/core/table-grid.ts`. (depends on Phase 2)
-- [ ] T011 [US1] Migrate `src/ui/header-utils.ts`: replace its local `nonInjectedRows`/`nonInjectedCells` with imports from `table-grid`; `injectPlusIcons` uses `gridRows`/`gridCells`; `headerColIndex` → `logicalColIndexOf`; `columnHasRowspanBodyCells` and `inferHeaderColumnType` use `columnCells`/`sourceCells` + `cellValue`.
-- [ ] T012 [P] [US1] Migrate `src/ui/toggle-injector.ts` statistics + frequency **column** sites to the logical index already carried in the event + `columnCells`/`gridCells` + `cellValue` (remove `th.cellIndex` and the ad-hoc per-call injected filters added in the earlier hotfix).
-- [ ] T013 [P] [US1] Migrate `src/enrichments/sort.ts` comparison reads to `columnCells`/`cellAt` + `cellValue`.
-- [ ] T014 [P] [US1] Migrate `src/enrichments/filter.ts` and `src/enrichments/filter-helpers.ts` predicate reads to `columnCells`/`cellAt` + `cellValue`.
-- [ ] T015 [P] [US1] Migrate `src/enrichments/frequency.ts` column extraction to `columnCells` + `cellValue`.
-- [ ] T016 [P] [US1] Migrate `src/enrichments/heatmap.ts` row lookup (replace `tbody tr:nth-child(index)` in `collectRowCells`) to `bodyRows`/`cellAt`.
+- [X] T010 [US1] Implement `cellAt`, `columnCells` (rowspan-safe, per-row scaffold filtering), `headerCellFor` (author-colspan rule per research R-6), and `logicalColIndexOf` in `src/core/table-grid.ts`. (depends on Phase 2)
+- [X] T011 [US1] Migrate `src/ui/header-utils.ts`: replace its local `nonInjectedRows`/`nonInjectedCells` with imports from `table-grid`; `injectPlusIcons` uses `gridRows`/`gridCells`; `headerColIndex` → `logicalColIndexOf`; `columnHasRowspanBodyCells` and `inferHeaderColumnType` use `columnCells`/`sourceCells` + `cellValue`.
+- [X] T012 [P] [US1] Migrate `src/ui/toggle-injector.ts` statistics + frequency **column** sites to the logical index already carried in the event + `columnCells`/`gridCells` + `cellValue` (remove `th.cellIndex` and the ad-hoc per-call injected filters added in the earlier hotfix).
+- [X] T013 [P] [US1] Migrate `src/enrichments/sort.ts` comparison reads to `columnCells`/`cellAt` + `cellValue`.
+- [X] T014 [P] [US1] Migrate `src/enrichments/filter.ts` and `src/enrichments/filter-helpers.ts` predicate reads to `columnCells`/`cellAt` + `cellValue`.
+- [X] T015 [P] [US1] Migrate `src/enrichments/frequency.ts` column extraction to `columnCells` + `cellValue`.
+- [X] T016 [P] [US1] Migrate `src/enrichments/heatmap.ts` row lookup (replace `tbody tr:nth-child(index)` in `collectRowCells`) to `bodyRows`/`cellAt`.
 
 **Checkpoint**: Logical column K resolves to the same author cells under `{none, row, col, both}` slider injection; MVP demonstrable.
 
@@ -85,12 +85,12 @@ assert identical results.
 
 ### Tests for User Story 2 ⚠️ (write first, ensure they FAIL / drive the work)
 
-- [ ] T018 [US2] Composition matrix test in `src/core/__tests__/table-grid.composition.test.ts`: for every point in `{none,row,col,both} × {none,+cumulative,+sparkline} × {unsorted,sorted}`, assert `columnCells(K)` equals the captured author cells for each source K, `headerCellFor(K)` is the author header, and `cellValue` is unpolluted — executed under **both** activation orders via the T003 `activateInOrder` helper. Encodes SC-001/SC-002/SC-003.
-- [ ] T019 [US2] Placement assertion (extend `src/ui/__tests__/header-utils.slider-placement.test.ts`): statistics/heatmap/sort/filter lozenges sit only on author cells and address the correct column under **both** activation orders.
+- [X] T018 [US2] Composition matrix test in `src/core/__tests__/table-grid.composition.test.ts`: for every point in `{none,row,col,both} × {none,+cumulative,+sparkline} × {unsorted,sorted}`, assert `columnCells(K)` equals the captured author cells for each source K, `headerCellFor(K)` is the author header, and `cellValue` is unpolluted — executed under **both** activation orders via the T003 `activateInOrder` helper. Encodes SC-001/SC-002/SC-003.
+- [X] T019 [US2] Placement assertion (extend `src/ui/__tests__/header-utils.slider-placement.test.ts`): statistics/heatmap/sort/filter lozenges sit only on author cells and address the correct column under **both** activation orders.
 
 ### Implementation for User Story 2
 
-- [ ] T017 [US2] Make `src/enrichments/slider-injection.ts` delegate its `nonInjectedRows`/`nonInjectedCells` to `table-grid` (single source of truth; removes the last copy of the helper).
+- [X] T017 [US2] Make `src/enrichments/slider-injection.ts` delegate its `nonInjectedRows`/`nonInjectedCells` to `table-grid` (single source of truth; removes the last copy of the helper).
 
 **Checkpoint**: Both activation orders produce identical resolution and placement (SC-002).
 
@@ -106,12 +106,12 @@ even after sort reorders the DOM; dimmed rows stay addressable.
 
 ### Tests for User Story 3 ⚠️ (write first, ensure they FAIL)
 
-- [ ] T020 [P] [US3] Unit tests in `src/core/__tests__/table-grid.test.ts`: `logicalRowIndexOf` invariant under a sort that reverses visual order (INV-5), dimmed (filtered) rows present in `bodyRows` and addressable, and `-1` for a non-body row.
+- [X] T020 [P] [US3] Unit tests in `src/core/__tests__/table-grid.test.ts`: `logicalRowIndexOf` invariant under a sort that reverses visual order (INV-5), dimmed (filtered) rows present in `bodyRows` and addressable, and `-1` for a non-body row.
 
 ### Implementation for User Story 3
 
-- [ ] T021 [US3] Implement `logicalRowIndexOf(table, row)` in `src/core/table-grid.ts` — consult `original-order.ts::getRecord` when present, else index within `bodyRows`. (depends on Phase 2)
-- [ ] T022 [P] [US3] Migrate `src/ui/toggle-injector.ts` row statistics + row frequency sites (and any remaining `tr.rowIndex` usage) to `bodyRows`/`gridCells`/`logicalRowIndexOf` + `cellValue`.
+- [X] T021 [US3] Implement `logicalRowIndexOf(table, row)` in `src/core/table-grid.ts` — consult `original-order.ts::getRecord` when present, else index within `bodyRows`. (depends on Phase 2)
+- [X] T022 [P] [US3] Migrate `src/ui/toggle-injector.ts` row statistics + row frequency sites (and any remaining `tr.rowIndex` usage) to `bodyRows`/`gridCells`/`logicalRowIndexOf` + `cellValue`.
 
 **Checkpoint**: Row identity stable across sort; dimmed rows addressable.
 
@@ -127,14 +127,14 @@ consumer reads only the author text; sort/filter/type-detection unaffected.
 
 ### Tests for User Story 4 ⚠️ (write first, ensure they FAIL)
 
-- [ ] T023 [P] [US4] Tests in `src/core/__tests__/table-grid.test.ts` (+ a targeted case in the composition suite): with lozenge clusters and slider readouts injected, `cellValue` and the migrated readers return unpolluted values for numeric AND categorical columns. Asserts INV-8 broadly across consumers.
+- [X] T023 [P] [US4] Tests in `src/core/__tests__/table-grid.test.ts` (+ a targeted case in the composition suite): with lozenge clusters and slider readouts injected, `cellValue` and the migrated readers return unpolluted values for numeric AND categorical columns. Asserts INV-8 broadly across consumers.
 
 ### Implementation for User Story 4
 
-- [ ] T024 [P] [US4] Migrate `src/core/type-detection.ts` and `src/core/table-detection.ts` cell reads to `sourceCells` + `cellValue`.
-- [ ] T025 [P] [US4] Migrate `src/enrichments/sparkline-column.ts`, `src/enrichments/compare-column.ts`, and `src/enrichments/cumulative-column.ts` source reads to `columnCells`/`sourceCells` + `cellValue`.
-- [ ] T026 [P] [US4] Migrate `src/enrichments/slider-threshold.ts` cell reads to `gridCells` + `cellValue`.
-- [ ] T027 [US4] Verify/migrate `src/enrichments/slider-injection.ts` header/data parsing (`readRawAxisHeaders`, `parseCell`) to read via `cellValue` so axis binding is robust when lozenges are present at slider-activation time (the slider-before/after-buttons permutation).
+- [X] T024 [P] [US4] Migrate `src/core/type-detection.ts` and `src/core/table-detection.ts` cell reads to `sourceCells` + `cellValue`.
+- [X] T025 [P] [US4] Migrate `src/enrichments/sparkline-column.ts`, `src/enrichments/compare-column.ts`, and `src/enrichments/cumulative-column.ts` source reads to `columnCells`/`sourceCells` + `cellValue`.
+- [X] T026 [P] [US4] Migrate `src/enrichments/slider-threshold.ts` cell reads to `gridCells` + `cellValue`.
+- [X] T027 [US4] Verify/migrate `src/enrichments/slider-injection.ts` header/data parsing (`readRawAxisHeaders`, `parseCell`) to read via `cellValue` so axis binding is robust when lozenges are present at slider-activation time (the slider-before/after-buttons permutation).
 
 **Checkpoint**: All value readers immune to injected-UI pollution under any order.
 
@@ -142,11 +142,11 @@ consumer reads only the author text; sort/filter/type-detection unaffected.
 
 ## Phase 7: Polish & Cross-Cutting Concerns
 
-- [ ] T028 [P] Grep audit across migrated consumers — confirm no live-DOM physical access (`cellIndex`, `.cells[`, `.rows[`, `tr:nth-child`) remains where the layer should be used (SC-006); document any intentionally-retained internal use inside `table-grid.ts`.
-- [ ] T029 [P] Optionally delegate `src/utils/view-state-url.ts::colKeyAt` to `headerRow`/`gridCells` from `table-grid` (consolidation; behaviour already correct).
-- [ ] T030 Run `yarn build` + `node scripts/bundle-size.js` — confirm IIFE within the 10 KB ceiling and net delta ≤ 0.5 KB gzipped, no new runtime dependency (SC-007, constitution §I).
-- [ ] T031 Run `yarn test` (Vitest unit + Storybook) and `yarn test:e2e` (Playwright) — all green, no regressions (SC-005).
-- [ ] T032 [P] Run `quickstart.md` validation end-to-end; update `CLAUDE.md`/`README.md` references if the module surface shifted during implementation.
+- [X] T028 [P] Grep audit across migrated consumers — confirm no live-DOM physical access (`cellIndex`, `.cells[`, `.rows[`, `tr:nth-child`) remains where the layer should be used (SC-006); document any intentionally-retained internal use inside `table-grid.ts`.
+- [X] T029 [P] Optionally delegate `src/utils/view-state-url.ts::colKeyAt` to `headerRow`/`gridCells` from `table-grid` (consolidation; behaviour already correct).
+- [X] T030 Run `yarn build` + `node scripts/bundle-size.js` — confirm IIFE within the 10 KB ceiling and net delta ≤ 0.5 KB gzipped, no new runtime dependency (SC-007, constitution §I).
+- [X] T031 Run `yarn test` (Vitest unit + Storybook) and `yarn test:e2e` (Playwright) — all green, no regressions (SC-005).
+- [X] T032 [P] Run `quickstart.md` validation end-to-end; update `CLAUDE.md`/`README.md` references if the module surface shifted during implementation.
 
 ---
 

--- a/src/core/__tests__/helpers/grid-fixture.ts
+++ b/src/core/__tests__/helpers/grid-fixture.ts
@@ -1,0 +1,183 @@
+/**
+ * Shared test harness for the table-grid addressing layer (spec 013).
+ *
+ * Builds the canonical numeric grid (numeric row + column headers + numeric
+ * body), captures each author cell's identity, and exposes the activation
+ * helpers the unit + composition suites compose in every order.
+ */
+
+import { expect } from 'vitest';
+import {
+  bodyRows,
+  gridCells,
+  sourceCells,
+  sourceColumnCount,
+  headerCellFor,
+  cellValue,
+  logicalRowIndexOf,
+} from '../../table-grid';
+import { addSlider } from '../../../enrichments/slider';
+import { setSort, type SortDirective } from '../../../utils/visible-rows';
+import { colKeyAt } from '../../../utils/view-state-url';
+import {
+  activateDirective,
+  getColumnKeys,
+  __flushVirtualColumnFrame,
+} from '../../../enrichments/virtual-column';
+// Side-effect imports: register the sort comparator + virtual-column renderers.
+import '../../../enrichments/sort';
+import '../../../enrichments/cumulative-column';
+import '../../../enrichments/sparkline-column';
+
+export interface CanonicalGrid {
+  table: HTMLTableElement;
+  /** Number of author source columns (includes the row-header column). */
+  sourceCols: number;
+  /** Number of author body rows. */
+  bodyRowCount: number;
+}
+
+/**
+ * Build a monotonic numeric grid with a `<thead>` (required by the virtual
+ * column scaffold) and numeric row/column headers (required by slider axis
+ * binding). Top-left cell is a categorical "GS" label, as in the real demos.
+ */
+export function buildNumericGrid(): CanonicalGrid {
+  const table = document.createElement('table');
+  if (!table.id) table.id = `gs-fixture-${Math.random().toString(36).slice(2, 8)}`;
+  table.innerHTML = `
+    <thead>
+      <tr><th>GS</th><th>10</th><th>20</th><th>30</th></tr>
+    </thead>
+    <tbody>
+      <tr><th>1000</th><td>4.2</td><td>5.1</td><td>5.9</td></tr>
+      <tr><th>2000</th><td>3.6</td><td>4.4</td><td>5.0</td></tr>
+      <tr><th>3000</th><td>3.0</td><td>3.7</td><td>4.2</td></tr>
+    </tbody>
+  `;
+  table.classList.add('grid-sight-enabled');
+  document.body.appendChild(table);
+  return { table, sourceCols: 4, bodyRowCount: 3 };
+}
+
+export interface CapturedIdentity {
+  /** `${logicalRowIndex}:${sourceColIndex}` → the author body cell element. */
+  cellByRC: Map<string, HTMLTableCellElement>;
+  /** Original trimmed text of each author body cell, same key. */
+  textByRC: Map<string, string>;
+  /** Author header cell per source column index. */
+  headerByCol: (HTMLTableCellElement | null)[];
+  sourceCols: number;
+}
+
+/** Capture each author body + header cell's identity BEFORE any activation. */
+export function captureIdentity(table: HTMLTableElement): CapturedIdentity {
+  const cols = sourceColumnCount(table);
+  const cellByRC = new Map<string, HTMLTableCellElement>();
+  const textByRC = new Map<string, string>();
+  bodyRows(table).forEach((row, ri) => {
+    const cells = sourceCells(row);
+    for (let k = 0; k < cols; k++) {
+      cellByRC.set(`${ri}:${k}`, cells[k]);
+      textByRC.set(`${ri}:${k}`, cellValue(cells[k]));
+    }
+  });
+  const headerByCol: (HTMLTableCellElement | null)[] = [];
+  for (let k = 0; k < cols; k++) headerByCol.push(headerCellFor(table, k));
+  return { cellByRC, textByRC, headerByCol, sourceCols: cols };
+}
+
+/**
+ * Assert the addressing layer still resolves every captured author cell after
+ * an arbitrary composition of activations: for each current body row, its
+ * logical (row, col) source cell is the same element + text captured at
+ * baseline, and the header for each source column is unchanged.
+ */
+export function expectIdentityPreserved(
+  table: HTMLTableElement,
+  captured: CapturedIdentity,
+): void {
+  for (const row of bodyRows(table)) {
+    const ri = logicalRowIndexOf(table, row);
+    const cells = gridCells(row);
+    for (let k = 0; k < captured.sourceCols; k++) {
+      const key = `${ri}:${k}`;
+      expect(cells[k]).toBe(captured.cellByRC.get(key));
+      expect(cellValue(cells[k])).toBe(captured.textByRC.get(key));
+    }
+  }
+  for (let k = 0; k < captured.sourceCols; k++) {
+    expect(headerCellFor(table, k)).toBe(captured.headerByCol[k]);
+  }
+}
+
+/* ── Activation helpers ─────────────────────────────────────────────── */
+
+export function enableRowSlider(table: HTMLTableElement): void {
+  addSlider(table, 'row');
+}
+
+export function enableColSlider(table: HTMLTableElement): void {
+  addSlider(table, 'col');
+}
+
+/** Add a cumulative virtual column over the given source column index. */
+export function addCumulativeColumn(
+  table: HTMLTableElement,
+  sourceColIndex = 1,
+): void {
+  const keys = getColumnKeys(table);
+  const key = keys[sourceColIndex];
+  activateDirective({
+    id: `cum-${key}`,
+    kind: 'cumulative',
+    tableEl: table,
+    sourceColKey: key,
+    mode: 'sum',
+    activationIndex: 0,
+  });
+  __flushVirtualColumnFrame();
+}
+
+export function addSparklineColumn(table: HTMLTableElement): void {
+  activateDirective({
+    id: 'spark',
+    kind: 'sparkline',
+    tableEl: table,
+    scale: 'per-row',
+    style: 'bar',
+  });
+  __flushVirtualColumnFrame();
+}
+
+/** Apply a sort on a logical column (default reverses to exercise INV-5). */
+export function applySort(
+  table: HTMLTableElement,
+  columnIndex = 1,
+  direction: 'asc' | 'desc' = 'desc',
+): void {
+  const directive: SortDirective = {
+    columnIndex,
+    columnKey: colKeyAt(table, columnIndex),
+    direction,
+  };
+  setSort(table, directive);
+}
+
+export type ActivationStep = 'row' | 'col' | 'cumulative' | 'sparkline' | 'sort';
+
+const STEP_FNS: Record<ActivationStep, (t: HTMLTableElement) => void> = {
+  row: enableRowSlider,
+  col: enableColSlider,
+  cumulative: addCumulativeColumn,
+  sparkline: addSparklineColumn,
+  sort: applySort,
+};
+
+/** Run a set of activation steps in a chosen order (for both-permutation testing). */
+export function activateInOrder(
+  table: HTMLTableElement,
+  order: ActivationStep[],
+): void {
+  for (const step of order) STEP_FNS[step](table);
+}

--- a/src/core/__tests__/table-grid.composition.test.ts
+++ b/src/core/__tests__/table-grid.composition.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Composition matrix for the table-grid addressing layer (spec 013, US2).
+ *
+ * For every point in {none,row,col,both} × {none,+cumulative,+sparkline} ×
+ * {unsorted,sorted}, run the activations under BOTH orders (enrichment-first
+ * vs slider-first) and assert the addressing layer resolves the same author
+ * cells, headers, and values for each source column. Encodes SC-001/SC-002/
+ * SC-003 (INV-2/INV-3).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { columnCells, cellValue, headerCellFor } from '../table-grid';
+import { removeAllSliders } from '../../enrichments/slider';
+import {
+  buildNumericGrid,
+  captureIdentity,
+  expectIdentityPreserved,
+  activateInOrder,
+  type ActivationStep,
+} from './helpers/grid-fixture';
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+afterEach(() => {
+  removeAllSliders();
+  document.body.innerHTML = '';
+});
+
+type SliderPoint = 'none' | 'row' | 'col' | 'both';
+type EnrichPoint = 'none' | 'cumulative' | 'sparkline';
+type SortPoint = 'unsorted' | 'sorted';
+
+const SLIDER_STEPS: Record<SliderPoint, ActivationStep[]> = {
+  none: [],
+  row: ['row'],
+  col: ['col'],
+  both: ['row', 'col'],
+};
+const ENRICH_STEPS: Record<EnrichPoint, ActivationStep[]> = {
+  none: [],
+  cumulative: ['cumulative'],
+  sparkline: ['sparkline'],
+};
+
+const SLIDERS: SliderPoint[] = ['none', 'row', 'col', 'both'];
+const ENRICHMENTS: EnrichPoint[] = ['none', 'cumulative', 'sparkline'];
+const SORTS: SortPoint[] = ['unsorted', 'sorted'];
+const ORDERS: Array<'enrichment-first' | 'slider-first'> = [
+  'enrichment-first',
+  'slider-first',
+];
+
+function buildOrder(
+  slider: SliderPoint,
+  enrich: EnrichPoint,
+  sort: SortPoint,
+  order: 'enrichment-first' | 'slider-first',
+): ActivationStep[] {
+  const sliderSteps = SLIDER_STEPS[slider];
+  const enrichSteps = ENRICH_STEPS[enrich];
+  const steps =
+    order === 'enrichment-first'
+      ? [...enrichSteps, ...sliderSteps]
+      : [...sliderSteps, ...enrichSteps];
+  if (sort === 'sorted') steps.push('sort');
+  return steps;
+}
+
+describe('addressing composition matrix (both activation orders)', () => {
+  for (const slider of SLIDERS) {
+    for (const enrich of ENRICHMENTS) {
+      for (const sort of SORTS) {
+        for (const order of ORDERS) {
+          it(`slider=${slider} enrich=${enrich} ${sort} (${order})`, () => {
+            const { table } = buildNumericGrid();
+            const captured = captureIdentity(table);
+            activateInOrder(table, buildOrder(slider, enrich, sort, order));
+            expectIdentityPreserved(table, captured);
+          });
+        }
+      }
+    }
+  }
+
+  it('produces identical resolution for the same end state reached two ways (SC-002)', () => {
+    // enrichment-first
+    const a = buildNumericGrid();
+    const capA = captureIdentity(a.table);
+    activateInOrder(a.table, ['cumulative', 'row', 'col']);
+
+    // slider-first
+    const b = buildNumericGrid();
+    const capB = captureIdentity(b.table);
+    activateInOrder(b.table, ['row', 'col', 'cumulative']);
+
+    for (let k = 0; k < capA.sourceCols; k++) {
+      const colA = columnCells(a.table, k).map(cellValue);
+      const colB = columnCells(b.table, k).map(cellValue);
+      expect(colA).toEqual(colB);
+      expect(cellValue(headerCellFor(a.table, k)!)).toBe(
+        cellValue(headerCellFor(b.table, k)!),
+      );
+    }
+    // Both gained exactly one virtual column at the same logical position.
+    expect(columnCells(a.table, capA.sourceCols)).toHaveLength(a.bodyRowCount);
+    expect(columnCells(b.table, capB.sourceCols)).toHaveLength(b.bodyRowCount);
+  });
+});

--- a/src/core/__tests__/table-grid.test.ts
+++ b/src/core/__tests__/table-grid.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Unit tests for the canonical table-grid addressing layer (spec 013).
+ *
+ * Covers the foundational primitives (classification, row/cell views, counts,
+ * cellValue), bidirectional translation (cellAt/columnCells/headerCellFor/
+ * logicalColIndexOf), logical row identity, and value purity — asserting the
+ * INV-1..INV-8 invariants from data-model.md.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  SCAFFOLD_ATTR,
+  VIRTUAL_COL_ATTR,
+  isScaffold,
+  isVirtualColumn,
+  gridRows,
+  headerRow,
+  bodyRows,
+  gridCells,
+  sourceCells,
+  sourceColumnCount,
+  gridColumnCount,
+  cellAt,
+  columnCells,
+  headerCellFor,
+  logicalColIndexOf,
+  logicalRowIndexOf,
+  cellValue,
+} from '../table-grid';
+import { removeAllSliders } from '../../enrichments/slider';
+import {
+  buildNumericGrid,
+  captureIdentity,
+  enableRowSlider,
+  enableColSlider,
+  addCumulativeColumn,
+  applySort,
+} from './helpers/grid-fixture';
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+afterEach(() => {
+  removeAllSliders();
+  document.body.innerHTML = '';
+});
+
+/* ── Classification (INV-4 markers) ─────────────────────────────────── */
+
+describe('classification', () => {
+  it('isScaffold reflects the data-gs-injected attribute', () => {
+    const td = document.createElement('td');
+    expect(isScaffold(td)).toBe(false);
+    td.setAttribute(SCAFFOLD_ATTR, '');
+    expect(isScaffold(td)).toBe(true);
+  });
+
+  it('isVirtualColumn reflects the data-gs-virtual-column attribute', () => {
+    const td = document.createElement('td');
+    expect(isVirtualColumn(td)).toBe(false);
+    td.setAttribute(VIRTUAL_COL_ATTR, 'cumulative');
+    expect(isVirtualColumn(td)).toBe(true);
+  });
+});
+
+/* ── Rows ───────────────────────────────────────────────────────────── */
+
+describe('row access', () => {
+  it('headerRow/bodyRows with an explicit <thead>', () => {
+    const { table } = buildNumericGrid();
+    const head = headerRow(table)!;
+    expect(head.cells[0].textContent).toBe('GS');
+    const body = bodyRows(table);
+    expect(body).toHaveLength(3);
+    expect(body[0].cells[0].textContent).toBe('1000');
+  });
+
+  it('headerRow/bodyRows with an implicit header (no <thead>)', () => {
+    const table = document.createElement('table');
+    table.innerHTML = `
+      <tr><th>Name</th><th>Age</th></tr>
+      <tr><td>Ann</td><td>30</td></tr>
+      <tr><td>Bob</td><td>40</td></tr>
+    `;
+    document.body.appendChild(table);
+    expect(headerRow(table)!.cells[0].textContent).toBe('Name');
+    const body = bodyRows(table);
+    expect(body).toHaveLength(2);
+    expect(body.map((r) => r.cells[0].textContent)).toEqual(['Ann', 'Bob']);
+  });
+
+  it('excludes <tfoot> rows from the body set (and from gridRows)', () => {
+    const table = document.createElement('table');
+    table.innerHTML = `
+      <thead><tr><th>Name</th><th>N</th></tr></thead>
+      <tbody><tr><td>Ann</td><td>1</td></tr><tr><td>Bob</td><td>2</td></tr></tbody>
+      <tfoot><tr><td>Total</td><td>3</td></tr></tfoot>
+    `;
+    document.body.appendChild(table);
+    expect(bodyRows(table)).toHaveLength(2);
+    const footRow = table.tFoot!.rows[0];
+    expect(gridRows(table)).not.toContain(footRow);
+    expect(bodyRows(table)).not.toContain(footRow);
+  });
+
+  it('keeps dimmed (filtered) rows in the body set (INV-5 support)', () => {
+    const { table } = buildNumericGrid();
+    const body0 = bodyRows(table);
+    body0[1].classList.add('gs-row--dimmed');
+    body0[1].setAttribute('data-gs-dimmed', 'true');
+    expect(bodyRows(table)).toContain(body0[1]);
+    expect(bodyRows(table)).toHaveLength(3);
+  });
+
+  it('excludes scaffold rows even when injected ahead of the real header (INV-2 prep)', () => {
+    const { table } = buildNumericGrid();
+    enableColSlider(table); // injects a scaffold top row
+    enableRowSlider(table); // injects a scaffold leading header + body cell
+    expect(table.querySelectorAll(`[${SCAFFOLD_ATTR}]`).length).toBeGreaterThan(0);
+    expect(gridCells(headerRow(table)!)[0].textContent).toBe('GS');
+    expect(bodyRows(table)).toHaveLength(3);
+    for (const r of gridRows(table)) expect(isScaffold(r)).toBe(false);
+  });
+});
+
+/* ── Cells + counts ─────────────────────────────────────────────────── */
+
+describe('cell views and counts', () => {
+  it('gridCells == sourceCells with no virtual columns; counts agree (INV-1/INV-4)', () => {
+    const { table } = buildNumericGrid();
+    const head = headerRow(table)!;
+    expect(gridCells(head)).toEqual(sourceCells(head));
+    expect(sourceColumnCount(table)).toBe(4);
+    expect(gridColumnCount(table)).toBe(4);
+  });
+
+  it('orders virtual columns after source columns; source ⊆ grid (INV-4)', () => {
+    const { table } = buildNumericGrid();
+    addCumulativeColumn(table, 1);
+    expect(gridColumnCount(table)).toBe(5);
+    expect(sourceColumnCount(table)).toBe(4);
+    const head = headerRow(table)!;
+    const grid = gridCells(head);
+    const source = sourceCells(head);
+    // source is a prefix of grid
+    expect(grid.slice(0, source.length)).toEqual(source);
+    // the trailing grid cell is the virtual one
+    expect(isVirtualColumn(grid[grid.length - 1])).toBe(true);
+  });
+
+  it('filters scaffold cells from both views', () => {
+    const { table } = buildNumericGrid();
+    enableRowSlider(table);
+    for (const row of bodyRows(table)) {
+      for (const c of gridCells(row)) expect(isScaffold(c)).toBe(false);
+      for (const c of sourceCells(row)) expect(isScaffold(c)).toBe(false);
+    }
+  });
+});
+
+/* ── cellValue (INV-1 / INV-8) ──────────────────────────────────────── */
+
+describe('cellValue', () => {
+  it('returns trimmed identity text for a clean cell', () => {
+    const td = document.createElement('td');
+    td.textContent = '  4.2  ';
+    expect(cellValue(td)).toBe('4.2');
+  });
+
+  it('strips a lozenge cluster injected into a header', () => {
+    const th = document.createElement('th');
+    th.textContent = '10';
+    const cluster = document.createElement('span');
+    cluster.className = 'gs-lozenge-cluster';
+    cluster.innerHTML = '<button class="gs-lozenge" data-gs-lozenge-id="sort">↕</button>';
+    th.appendChild(cluster);
+    expect(cellValue(th)).toBe('10');
+  });
+
+  it('strips a slider readout injected into a cell', () => {
+    const td = document.createElement('td');
+    td.textContent = 'Region A';
+    const readout = document.createElement('div');
+    readout.setAttribute('data-gs-slider-readout', 'interpolated');
+    readout.textContent = '—';
+    td.appendChild(readout);
+    expect(cellValue(td)).toBe('Region A');
+  });
+
+  it('does not mutate the cell it reads (INV-6)', () => {
+    const th = document.createElement('th');
+    th.innerHTML = '10<span class="gs-lozenge-cluster"><button class="gs-lozenge">x</button></span>';
+    const before = th.innerHTML;
+    cellValue(th);
+    expect(th.innerHTML).toBe(before);
+  });
+});
+
+/* ── Translation: cellAt / columnCells / headerCellFor / logicalColIndexOf ─ */
+
+describe('bidirectional translation', () => {
+  it('columnCells(K) is rowspan-safe under a row slider (INV-2)', () => {
+    const { table } = buildNumericGrid();
+    const captured = captureIdentity(table);
+    enableRowSlider(table);
+    enableColSlider(table);
+    for (let k = 0; k < captured.sourceCols; k++) {
+      const cells = columnCells(table, k);
+      expect(cells).toHaveLength(3);
+      for (let ri = 0; ri < 3; ri++) {
+        expect(cells[ri]).toBe(captured.cellByRC.get(`${ri}:${k}`));
+      }
+    }
+  });
+
+  it('cellAt resolves the same author cell with and without sliders', () => {
+    const { table } = buildNumericGrid();
+    const before = cellAt(table, 0, 1);
+    enableRowSlider(table);
+    expect(cellAt(table, 0, 1)).toBe(before);
+  });
+
+  it('virtual columns are addressable after the source columns', () => {
+    const { table } = buildNumericGrid();
+    addCumulativeColumn(table, 1);
+    const virtualCol = gridColumnCount(table) - 1; // == 4
+    const cells = columnCells(table, virtualCol);
+    expect(cells).toHaveLength(3);
+    for (const c of cells) expect(isVirtualColumn(c)).toBe(true);
+    expect(headerCellFor(table, virtualCol)).not.toBeNull();
+    expect(isVirtualColumn(headerCellFor(table, virtualCol)!)).toBe(true);
+  });
+
+  it('headerCellFor returns the author header for each source column', () => {
+    const { table } = buildNumericGrid();
+    expect(headerCellFor(table, 0)!.textContent).toBe('GS');
+    expect(headerCellFor(table, 1)!.textContent).toBe('10');
+    expect(headerCellFor(table, 3)!.textContent).toBe('30');
+  });
+
+  it('headerCellFor respects an author colspan header (R-6)', () => {
+    const table = document.createElement('table');
+    table.innerHTML = `
+      <thead>
+        <tr><th colspan="2">Span</th><th>C</th></tr>
+      </thead>
+      <tbody><tr><td>1</td><td>2</td><td>3</td></tr></tbody>
+    `;
+    document.body.appendChild(table);
+    const span = headerRow(table)!.cells[0];
+    expect(headerCellFor(table, 0)).toBe(span);
+    expect(headerCellFor(table, 1)).toBe(span); // covered slot returns same header
+    expect(headerCellFor(table, 2)!.textContent).toBe('C');
+  });
+
+  it('logicalColIndexOf is the inverse of header addressing', () => {
+    const { table } = buildNumericGrid();
+    enableRowSlider(table);
+    for (let k = 0; k < 4; k++) {
+      const header = headerCellFor(table, k)!;
+      expect(logicalColIndexOf(header)).toBe(k);
+    }
+  });
+
+  it('out-of-range coordinates yield null/[]/-1 (INV-7)', () => {
+    const { table } = buildNumericGrid();
+    expect(cellAt(table, 99, 0)).toBeNull();
+    expect(cellAt(table, 0, 99)).toBeNull();
+    expect(cellAt(table, -1, 0)).toBeNull();
+    expect(columnCells(table, 99)).toEqual([]);
+    expect(columnCells(table, -1)).toEqual([]);
+    expect(headerCellFor(table, 99)).toBeNull();
+    const detached = document.createElement('td');
+    expect(logicalColIndexOf(detached)).toBe(-1);
+  });
+});
+
+/* ── Logical row identity (INV-5) ───────────────────────────────────── */
+
+describe('logical row identity', () => {
+  it('is invariant under a sort that reverses visual order (INV-5)', () => {
+    const { table } = buildNumericGrid();
+    const before = bodyRows(table);
+    const idxBefore = before.map((r) => logicalRowIndexOf(table, r));
+    expect(idxBefore).toEqual([0, 1, 2]);
+
+    applySort(table, 1, 'asc'); // values 4.2,3.6,3.0 asc → reverses DOM order
+
+    // DOM order changed…
+    const afterDom = bodyRows(table).map((r) => r.cells[0].textContent);
+    expect(afterDom).toEqual(['3000', '2000', '1000']);
+    // …but each original row keeps its logical identity.
+    for (const row of before) {
+      const idx = logicalRowIndexOf(table, row);
+      expect(idx).toBe(idxBefore[before.indexOf(row)]);
+    }
+  });
+
+  it('keeps dimmed rows addressable', () => {
+    const { table } = buildNumericGrid();
+    const body = bodyRows(table);
+    body[1].classList.add('gs-row--dimmed');
+    expect(logicalRowIndexOf(table, body[1])).toBe(1);
+  });
+
+  it('returns -1 for a non-body row', () => {
+    const { table } = buildNumericGrid();
+    expect(logicalRowIndexOf(table, headerRow(table)!)).toBe(-1);
+    const orphan = document.createElement('tr');
+    expect(logicalRowIndexOf(table, orphan)).toBe(-1);
+  });
+});
+
+/* ── Value purity across consumers (US4 / INV-8) ────────────────────── */
+
+describe('value purity under injected UI', () => {
+  it('cellValue stays clean for numeric and categorical cells with lozenges', () => {
+    const numeric = document.createElement('th');
+    numeric.innerHTML = '42<span class="gs-lozenge-cluster"><button class="gs-lozenge" data-gs-lozenge-id="statistics">#</button></span>';
+    expect(cellValue(numeric)).toBe('42');
+
+    const categorical = document.createElement('th');
+    categorical.innerHTML = 'North<span class="gs-lozenge-cluster"><button class="gs-lozenge" data-gs-lozenge-id="frequency">#</button></span>';
+    expect(cellValue(categorical)).toBe('North');
+  });
+});

--- a/src/core/table-grid.ts
+++ b/src/core/table-grid.ts
@@ -1,0 +1,227 @@
+/**
+ * Canonical table-grid addressing layer (spec 013-table-grid-addressing).
+ *
+ * The single authority for translating between a LOGICAL (row, column)
+ * coordinate and a PHYSICAL live-DOM cell, and back. Everything is derived
+ * from the live DOM plus the existing structural markers at call time — no
+ * cached snapshots, no new markers — so results depend only on the current
+ * DOM and never on the order in which enrichments were activated.
+ *
+ *  - Scaffolding cells/rows (`data-gs-injected`) are never part of the grid.
+ *  - Virtual columns (`data-gs-virtual-column`) are real, addressable columns
+ *    ordered after the source columns.
+ *  - `cellValue` is the canonical "author data text of a cell" reader.
+ *  - `logicalRowIndexOf` delegates to the Original Order Record for identity.
+ *
+ * All functions are PURE READS of the DOM; none mutate it.
+ */
+
+import { getRecord } from '../utils/original-order';
+
+/* ── Marker constants (single source of truth) ──────────────────────── */
+
+export const SCAFFOLD_ATTR = 'data-gs-injected';
+export const VIRTUAL_COL_ATTR = 'data-gs-virtual-column';
+
+/** Grid-Sight-owned descendants that `cellValue` strips before reading text. */
+const GS_OWNED_SELECTOR = [
+  '.gs-lozenge-cluster',
+  '.gs-lozenge',
+  '.gs-vc-lozenge',
+  '.gs-plus-icon',
+  '[data-gs-slider-readout]',
+  '[data-gs-lozenge-id]',
+  '[data-gs-vc-kind]',
+].join(',');
+
+/* ── Classification ─────────────────────────────────────────────────── */
+
+/** True for slider scaffolding rows/cells — never part of the logical grid. */
+export function isScaffold(el: Element): boolean {
+  return el.hasAttribute(SCAFFOLD_ATTR);
+}
+
+/** True for a Grid-Sight-computed (virtual) column cell. */
+export function isVirtualColumn(cell: Element): boolean {
+  return cell.hasAttribute(VIRTUAL_COL_ATTR);
+}
+
+/* ── Rows ───────────────────────────────────────────────────────────── */
+
+/** All non-scaffold rows, in DOM order (header + body, excludes <tfoot>).
+ *  `table.rows` already orders thead rows, then table/tbody rows, then tfoot
+ *  rows (HTML spec), so filtering out scaffold + footer rows preserves the
+ *  header-then-body order. */
+export function gridRows(table: HTMLTableElement): HTMLTableRowElement[] {
+  const foot = footerRowSet(table);
+  return Array.from(table.rows).filter((r) => !isScaffold(r) && !foot.has(r));
+}
+
+function footerRowSet(table: HTMLTableElement): Set<HTMLTableRowElement> {
+  return new Set(table.tFoot ? Array.from(table.tFoot.rows) : []);
+}
+
+/**
+ * Partition the non-scaffold rows into header + body.
+ *
+ * Mirrors the header-detection rule in
+ * `src/utils/original-order.ts::getDataRows` (header is `table.rows[0]` iff it
+ * is the first row of the implicit/`tbody` block and contains a `<th>`; with an
+ * explicit `<thead>` the body starts at the data rows). The rule is applied
+ * AFTER removing scaffold rows: a row slider injects a scaffold `<tr>` carrying
+ * a `<th>` corner ahead of the real header, so running the heuristic over the
+ * raw rows (as `getDataRows` does) would mistake that scaffold row for the
+ * header. We mirror rather than reuse `getDataRows` for exactly this reason.
+ */
+function partitionRows(table: HTMLTableElement): {
+  header: HTMLTableRowElement | null;
+  body: HTMLTableRowElement[];
+} {
+  const thead = table.tHead;
+  const theadRows = thead
+    ? Array.from(thead.rows).filter((r) => !isScaffold(r))
+    : [];
+  const tbody = table.tBodies[0];
+  const tbodyRows = tbody
+    ? Array.from(tbody.rows).filter((r) => !isScaffold(r))
+    : [];
+
+  if (theadRows.length > 0) {
+    // Explicit head: header = first head row; body = all tbody data rows.
+    return { header: theadRows[0], body: tbodyRows };
+  }
+  // No <thead>: the de-facto header is the first tbody row iff it has a <th>.
+  if (
+    tbodyRows.length > 0 &&
+    Array.from(tbodyRows[0].cells).some((c) => c.tagName === 'TH')
+  ) {
+    return { header: tbodyRows[0], body: tbodyRows.slice(1) };
+  }
+  return { header: tbodyRows[0] ?? null, body: tbodyRows };
+}
+
+/** The header row (first non-scaffold row; reuses original-order header rule). */
+export function headerRow(table: HTMLTableElement): HTMLTableRowElement | null {
+  return partitionRows(table).header;
+}
+
+/** Non-scaffold data rows after the header, excluding <tfoot>. Dimmed rows kept. */
+export function bodyRows(table: HTMLTableElement): HTMLTableRowElement[] {
+  return partitionRows(table).body;
+}
+
+/* ── Cells within a row ─────────────────────────────────────────────── */
+
+/** Source + virtual columns (non-scaffold), DOM order: source first, virtual
+ *  last (virtual columns are appended at the right edge). */
+export function gridCells(row: HTMLTableRowElement): HTMLTableCellElement[] {
+  return Array.from(row.cells).filter((c) => !isScaffold(c));
+}
+
+/** Source columns only (also excludes virtual). */
+export function sourceCells(row: HTMLTableRowElement): HTMLTableCellElement[] {
+  return Array.from(row.cells).filter(
+    (c) => !isScaffold(c) && !isVirtualColumn(c),
+  );
+}
+
+/* ── Column counts ──────────────────────────────────────────────────── */
+
+export function sourceColumnCount(table: HTMLTableElement): number {
+  const h = headerRow(table);
+  return h ? sourceCells(h).length : 0;
+}
+
+export function gridColumnCount(table: HTMLTableElement): number {
+  const h = headerRow(table);
+  return h ? gridCells(h).length : 0;
+}
+
+/* ── Bidirectional translation ──────────────────────────────────────── */
+
+/** The cell at logical (rowIndex, colIndex), or null if out of range.
+ *  rowIndex addresses bodyRows(); colIndex addresses gridCells() of that row.
+ *  Rowspan-safe: scaffold cells are filtered per row, so the K-th grid cell of
+ *  a row that carries an injected rowspan cell still resolves to the same
+ *  author column as a row that does not (INV-2). */
+export function cellAt(
+  table: HTMLTableElement,
+  rowIndex: number,
+  colIndex: number,
+): HTMLTableCellElement | null {
+  if (rowIndex < 0 || colIndex < 0) return null;
+  const row = bodyRows(table)[rowIndex];
+  if (!row) return null;
+  return gridCells(row)[colIndex] ?? null;
+}
+
+/** Every body cell of logical column `colIndex`, one per body row, in body
+ *  order. Empty array if colIndex is out of range. Rowspan-safe. */
+export function columnCells(
+  table: HTMLTableElement,
+  colIndex: number,
+): HTMLTableCellElement[] {
+  if (colIndex < 0) return [];
+  const out: HTMLTableCellElement[] = [];
+  for (const row of bodyRows(table)) {
+    const cell = gridCells(row)[colIndex];
+    if (cell) out.push(cell);
+  }
+  return out;
+}
+
+/** The header cell for logical column `colIndex`, or null. For an author
+ *  colspan header, any covered slot returns that header cell (R-6). */
+export function headerCellFor(
+  table: HTMLTableElement,
+  colIndex: number,
+): HTMLTableCellElement | null {
+  if (colIndex < 0) return null;
+  const h = headerRow(table);
+  if (!h) return null;
+  let slot = 0;
+  for (const cell of gridCells(h)) {
+    const span = Math.max(1, cell.colSpan || 1);
+    if (colIndex < slot + span) return cell;
+    slot += span;
+  }
+  return null;
+}
+
+/** Logical column index of `cell` within its row's grid cells, or -1. */
+export function logicalColIndexOf(cell: HTMLTableCellElement): number {
+  const row = cell.closest('tr');
+  if (!row) return -1;
+  return gridCells(row).indexOf(cell);
+}
+
+/** Logical row identity: index in the Original Order Record when present, else
+ *  index within bodyRows(). Stable across sort reorder (INV-5). -1 if the row
+ *  is not a body row of this table. */
+export function logicalRowIndexOf(
+  table: HTMLTableElement,
+  row: HTMLTableRowElement,
+): number {
+  const record = getRecord(table);
+  if (record) {
+    const idx = record.indexOf(row);
+    if (idx >= 0) return idx;
+  }
+  return bodyRows(table).indexOf(row);
+}
+
+/* ── Canonical value ────────────────────────────────────────────────── */
+
+/** The author data text of a cell, excluding Grid-Sight-injected UI (lozenge
+ *  clusters, slider readouts, etc.), trimmed. For a clean cell, equals
+ *  cell.textContent.trim() (INV-1 / INV-8). Pure: never mutates `cell`. */
+export function cellValue(cell: HTMLTableCellElement): string {
+  if (!cell.querySelector(GS_OWNED_SELECTOR)) {
+    return (cell.textContent ?? '').trim();
+  }
+  const clone = cell.cloneNode(true) as HTMLElement;
+  for (const node of Array.from(clone.querySelectorAll(GS_OWNED_SELECTOR))) {
+    node.remove();
+  }
+  return (clone.textContent ?? '').trim();
+}

--- a/src/core/type-detection.ts
+++ b/src/core/type-detection.ts
@@ -1,3 +1,5 @@
+import { gridRows, sourceCells, cellValue } from './table-grid';
+
 /**
  * Type definitions for column type detection
  */
@@ -217,19 +219,8 @@ export function analyzeTable(
  */
 export function extractTableData(table: HTMLTableElement): string[][] {
   if (!table.rows) return [];
-  
-  const rows: string[][] = [];
-  
-  for (let i = 0; i < table.rows.length; i++) {
-    const row = table.rows[i];
-    const rowData: string[] = [];
-    
-    for (let j = 0; j < row.cells.length; j++) {
-      rowData.push(row.cells[j]?.textContent?.trim() || '');
-    }
-    
-    rows.push(rowData);
-  }
-  
-  return rows;
+  // Read author source cells via the canonical addressing layer: scaffold rows
+  // and virtual columns are excluded and injected UI is stripped, so column-type
+  // detection sees only author data regardless of active enrichments (013).
+  return gridRows(table).map((row) => sourceCells(row).map(cellValue));
 }

--- a/src/enrichments/compare-column.ts
+++ b/src/enrichments/compare-column.ts
@@ -10,10 +10,12 @@ import type {
 } from '../types/virtual-column';
 import { cleanNumericCell } from '../core/type-detection';
 import { registerRenderer, getSourceColumnIndex } from './virtual-column';
+import { sourceCells, headerCellFor, cellValue } from '../core/table-grid';
 
 function getRowValue(row: HTMLTableRowElement, colIndex: number): number | null {
-  if (colIndex < 0 || colIndex >= row.cells.length) return null;
-  return cleanNumericCell(row.cells[colIndex]?.textContent ?? '');
+  const cells = sourceCells(row);
+  if (colIndex < 0 || colIndex >= cells.length) return null;
+  return cleanNumericCell(cellValue(cells[colIndex]));
 }
 
 export function computeDelta(
@@ -52,15 +54,9 @@ function format(value: number, mode: 'abs' | 'rel' | 'percent'): string {
 }
 
 function getHeaderLabel(table: HTMLTableElement, colIdx: number): string {
-  const head = table.tHead?.rows[0];
-  const cell = head?.cells[colIdx];
+  const cell = headerCellFor(table, colIdx);
   if (!cell) return `col-${colIdx}`;
-  let text = '';
-  cell.childNodes.forEach((n) => {
-    if (n.nodeType === 3) text += n.textContent;
-  });
-  text = text.trim();
-  return text || `col-${colIdx}`;
+  return cellValue(cell) || `col-${colIdx}`;
 }
 
 const compareRenderer: Renderer<CompareDirective> = {

--- a/src/enrichments/cumulative-column.ts
+++ b/src/enrichments/cumulative-column.ts
@@ -11,11 +11,12 @@ import type {
 } from '../types/virtual-column';
 import { cleanNumericCell } from '../core/type-detection';
 import { registerRenderer, getSourceColumnIndex } from './virtual-column';
+import { sourceCells, headerCellFor, cellValue } from '../core/table-grid';
 
 function getRowValue(row: HTMLTableRowElement, colIndex: number): number | null {
-  if (colIndex < 0 || colIndex >= row.cells.length) return null;
-  const text = row.cells[colIndex]?.textContent ?? '';
-  return cleanNumericCell(text);
+  const cells = sourceCells(row);
+  if (colIndex < 0 || colIndex >= cells.length) return null;
+  return cleanNumericCell(cellValue(cells[colIndex]));
 }
 
 function getColIndex(directive: CumulativeDirective): number {
@@ -134,18 +135,10 @@ const cumulativeRenderer: Renderer<CumulativeDirective> = {
   kind: 'cumulative',
 
   headerText(directive) {
-    const head = directive.tableEl.tHead?.rows[0];
     const colIdx = getColIndex(directive);
-    const cell = head?.cells[colIdx];
-    // Use only text nodes (skip lozenge button text).
-    let sourceLabel = '';
-    if (cell) {
-      cell.childNodes.forEach((n) => {
-        if (n.nodeType === 3) sourceLabel += n.textContent;
-      });
-      sourceLabel = sourceLabel.trim();
-    }
-    if (!sourceLabel) sourceLabel = directive.sourceColKey;
+    const cell = headerCellFor(directive.tableEl, colIdx);
+    // cellValue strips injected lozenge/readout UI, leaving the author label.
+    const sourceLabel = (cell ? cellValue(cell) : '') || directive.sourceColKey;
     return `Σ ${sourceLabel}`;
   },
 

--- a/src/enrichments/filter-helpers.ts
+++ b/src/enrichments/filter-helpers.ts
@@ -4,11 +4,12 @@
  */
 
 import { cleanNumericCell } from '../core/type-detection';
+import { gridCells, cellValue } from '../core/table-grid';
 
 export function readNumericCell(row: HTMLTableRowElement, columnIndex: number): number | null {
-  const cell = row.cells[columnIndex];
+  const cell = gridCells(row)[columnIndex];
   if (!cell) return null;
-  const raw = (cell.textContent ?? '').trim();
+  const raw = cellValue(cell);
   return raw === '' ? null : cleanNumericCell(raw);
 }
 

--- a/src/enrichments/filter.ts
+++ b/src/enrichments/filter.ts
@@ -7,6 +7,7 @@
 
 import type { FilterDirective, FilterPredicate } from '../utils/visible-rows';
 import { readNumericCell, withinRange } from './filter-helpers';
+import { gridCells, columnCells, cellValue } from '../core/table-grid';
 
 /* ── Numeric range ──────────────────────────────────────────────────── */
 
@@ -53,8 +54,8 @@ export function categoricalInclusion(args: CategoricalArgs): FilterPredicate {
     columnIndex,
     columnKey,
     test(row: HTMLTableRowElement): boolean {
-      const cell = row.cells[columnIndex];
-      const raw = cell ? (cell.textContent ?? '').trim() : '';
+      const cell = gridCells(row)[columnIndex];
+      const raw = cell ? cellValue(cell) : '';
       if (raw === '') return !hideEmpty && allowedSet.has('');
       return allowedSet.has(raw);
     },
@@ -70,10 +71,8 @@ export function collectCategoricalValues(
   columnIndex: number
 ): Map<string, number> {
   const out = new Map<string, number>();
-  const tbody = table.tBodies[0];
-  if (!tbody) return out;
-  for (const row of Array.from(tbody.rows)) {
-    const v = (row.cells[columnIndex]?.textContent ?? '').trim();
+  for (const cell of columnCells(table, columnIndex)) {
+    const v = cellValue(cell);
     out.set(v, (out.get(v) ?? 0) + 1);
   }
   return out;

--- a/src/enrichments/frequency.ts
+++ b/src/enrichments/frequency.ts
@@ -1,5 +1,6 @@
 import { isCategoricalColumn } from '../core/type-detection';
 import { analyzeFrequencies } from '../utils/frequency';
+import { columnCells, gridCells, headerCellFor, cellValue } from '../core/table-grid';
 
 const FREQUENCY_CLASS = 'gs-frequency';
 
@@ -26,28 +27,18 @@ export function applyFrequencyAnalysis(
   index: number,
   type: 'row' | 'column' = 'column'
 ): Array<[string, number, number]> {
-  // Get the cells to analyze
-  const cells: HTMLTableCellElement[] = [];
-  
-  if (type === 'column') {
-    // For columns, get all cells in the specified column index
-    const rows = table.tBodies[0]?.rows || table.rows;
-    for (let i = 0; i < rows.length; i++) {
-      const cell = rows[i].cells[index];
-      if (cell) cells.push(cell);
-    }
-  } else {
-    // For rows, get all cells in the specified row
-    const row = table.rows[index];
-    if (row) {
-      for (let i = 0; i < row.cells.length; i++) {
-        cells.push(row.cells[i]);
-      }
-    }
-  }
-  
+  // Get the cells to analyze via the canonical addressing layer so slider
+  // scaffolding / injected UI never shift the column or pollute values (013).
+  const cells: HTMLTableCellElement[] =
+    type === 'column'
+      ? columnCells(table, index)
+      : (() => {
+          const row = table.rows[index];
+          return row ? gridCells(row) : [];
+        })();
+
   // Extract cell values
-  const values = cells.map(cell => cell.textContent || '');
+  const values = cells.map(cellValue);
   
   // Check if the column is categorical
   if (!isCategoricalColumn(values)) {
@@ -63,10 +54,13 @@ export function applyFrequencyAnalysis(
   }
   
   // Mark the row/column as having frequency analysis
-  const header = type === 'column' 
-    ? table.rows[0]?.cells[index]
-    : table.rows[index]?.cells[0];
-    
+  const header = type === 'column'
+    ? headerCellFor(table, index)
+    : (() => {
+        const row = table.rows[index];
+        return row ? gridCells(row)[0] : undefined;
+      })();
+
   if (header) {
     header.classList.add(`${FREQUENCY_CLASS}-header`);
     

--- a/src/enrichments/heatmap.ts
+++ b/src/enrichments/heatmap.ts
@@ -1,4 +1,5 @@
 import { cleanNumericCell } from '../core/type-detection';
+import { columnCells, bodyRows, gridCells, cellValue } from '../core/table-grid';
 
 // Define heatmap type to include 'table' for table-wide heatmaps
 export type HeatmapType = 'row' | 'column' | 'table';
@@ -157,15 +158,9 @@ function pickColor(value: number, min: number, max: number, colorScale: string[]
 
 function collectColumnCells(table: HTMLTableElement, index: number): { cell: HTMLTableCellElement; value: number }[] {
   const out: { cell: HTMLTableCellElement; value: number }[] = [];
-  const rows = Array.from(table.rows).filter(
-    r => !r.hasAttribute('data-gs-injected') && !r.classList.contains('gs-header-row')
-  );
-  // rows[0] is the header row; data rows start at rows[1].
-  for (let i = 1; i < rows.length; i++) {
-    const cells = Array.from(rows[i].cells).filter(c => !c.hasAttribute('data-gs-injected'));
-    const cell = cells[index];
-    if (!cell || cell.tagName.toLowerCase() !== 'td') continue;
-    const v = cleanNumericCell(cell.textContent || '');
+  for (const cell of columnCells(table, index)) {
+    if (cell.tagName.toLowerCase() !== 'td') continue;
+    const v = cleanNumericCell(cellValue(cell));
     if (v !== null) out.push({ cell, value: v });
   }
   return out;
@@ -173,12 +168,14 @@ function collectColumnCells(table: HTMLTableElement, index: number): { cell: HTM
 
 function collectRowCells(table: HTMLTableElement, index: number): { cell: HTMLTableCellElement; value: number }[] {
   const out: { cell: HTMLTableCellElement; value: number }[] = [];
-  const row = table.querySelector<HTMLTableRowElement>(`tbody tr:nth-child(${index})`);
+  // `index` is the 1-based body-row position (matches the key the lozenge
+  // producers derive from bodyRows); resolve it through the addressing layer
+  // instead of `tbody tr:nth-child(index)` so slider scaffolding can't shift it.
+  const row = bodyRows(table)[index - 1];
   if (!row) return out;
-  const cells = Array.from(row.cells).filter(c => !c.hasAttribute('data-gs-injected'));
-  cells.forEach((cell, cellIndex) => {
+  gridCells(row).forEach((cell, cellIndex) => {
     if (cellIndex === 0 && cell.tagName.toLowerCase() === 'th') return;
-    const v = cleanNumericCell(cell.textContent || '');
+    const v = cleanNumericCell(cellValue(cell));
     if (v !== null) out.push({ cell, value: v });
   });
   return out;

--- a/src/enrichments/slider-injection.ts
+++ b/src/enrichments/slider-injection.ts
@@ -10,6 +10,13 @@
 import { parseHeaderNumber } from '../utils/sync-key';
 import { SLIDER_HIGHLIGHT_CLASSES } from './slider-readout';
 import type { EquationSnapshot } from './equation-panel';
+import {
+  gridRows,
+  bodyRows,
+  headerRow as gridHeaderRow,
+  sourceCells,
+  cellValue,
+} from '../core/table-grid';
 
 export type Axis = 'row' | 'col';
 
@@ -50,27 +57,24 @@ export const tableContexts = new WeakMap<HTMLTableElement, TableContext>();
 /* Parsing helpers                                                            */
 /* ────────────────────────────────────────────────────────────────────────── */
 
-function nonInjectedRows(table: HTMLTableElement): HTMLTableRowElement[] {
-  return Array.from(table.rows).filter(r => !r.hasAttribute('data-gs-injected'));
-}
-
-function nonInjectedCells(row: HTMLTableRowElement): HTMLTableCellElement[] {
-  return Array.from(row.cells).filter(c => !c.hasAttribute('data-gs-injected'));
-}
-
+/** Slider axis binding reads AUTHOR SOURCE cells only — virtual columns and
+ *  injected scaffolding are excluded — via the canonical addressing layer, so
+ *  axis binding is robust no matter what enrichments are active or the order
+ *  they were activated (spec 013, R-2/R-5). `cellValue` strips injected UI so a
+ *  lozenge present at slider-activation time can't corrupt the parsed value. */
 function cellText(cell: HTMLTableCellElement): string {
-  return cell.textContent?.trim() ?? '';
+  return cellValue(cell);
 }
 
 export function readRawAxisHeaders(table: HTMLTableElement, axis: Axis): string[] {
-  const rows = nonInjectedRows(table);
   if (axis === 'col') {
-    if (!rows[0]) return [];
-    return nonInjectedCells(rows[0]).slice(1).map(cellText);
+    const header = gridHeaderRow(table);
+    if (!header) return [];
+    return sourceCells(header).slice(1).map(cellText);
   }
   // axis === 'row'
-  return rows.slice(1)
-    .map(nonInjectedCells)
+  return bodyRows(table)
+    .map(sourceCells)
     .filter(cells => cells.length > 0)
     .map(cells => cellText(cells[0]));
 }
@@ -81,16 +85,15 @@ function parseCell(cell: HTMLTableCellElement): number {
 }
 
 function readDataRowAsNumbers(row: HTMLTableRowElement): number[] {
-  const cells = nonInjectedCells(row).slice(1);
+  const cells = sourceCells(row).slice(1);
   const out: number[] = [];
   for (const cell of cells) out.push(parseCell(cell));
   return out;
 }
 
 export function readRawCellMatrix(table: HTMLTableElement): number[][] {
-  const dataRows = nonInjectedRows(table).slice(1);
   const out: number[][] = [];
-  for (const row of dataRows) out.push(readDataRowAsNumbers(row));
+  for (const row of bodyRows(table)) out.push(readDataRowAsNumbers(row));
   return out;
 }
 
@@ -146,9 +149,8 @@ export function buildAxisBinding(table: HTMLTableElement, axis: Axis): AxisBindi
 /* ────────────────────────────────────────────────────────────────────────── */
 
 function tagDataCells(table: HTMLTableElement): void {
-  const rows = nonInjectedRows(table).slice(1);
-  rows.forEach((row, i) => {
-    nonInjectedCells(row).slice(1).forEach((cell, j) => {
+  bodyRows(table).forEach((row, i) => {
+    sourceCells(row).slice(1).forEach((cell, j) => {
       cell.setAttribute('data-gs-rc', `${i}:${j}`);
     });
   });
@@ -221,7 +223,7 @@ export function ensureTopRow(ctx: TableContext): HTMLTableRowElement {
   tr.appendChild(corner);
   tr.appendChild(colSlot);
 
-  const firstOriginal = nonInjectedRows(ctx.table)[0];
+  const firstOriginal = gridRows(ctx.table)[0];
   const tbody = ctx.table.tBodies[0] ?? ctx.table;
   if (firstOriginal) {
     firstOriginal.parentElement!.insertBefore(tr, firstOriginal);
@@ -260,14 +262,16 @@ function buildRowSliderCell(rowSpan: number): HTMLTableCellElement {
 export function ensureRowSliderSlot(ctx: TableContext): HTMLTableCellElement {
   if (ctx.rowSliderCell) return ctx.rowSliderCell;
 
-  const headerRow = nonInjectedRows(ctx.table)[0];
+  const headerRow = gridHeaderRow(ctx.table);
   if (!headerRow) throw new Error('No original header row found');
 
   const headerCell = buildRowHeaderCell();
   headerRow.insertBefore(headerCell, headerRow.firstChild);
 
   const cell = buildRowSliderCell(ctx.dataRowCount);
-  const firstDataRow = headerRow.nextElementSibling as HTMLTableRowElement | null;
+  // First body row (works whether the header lives in <thead> or the implicit
+  // tbody block — `nextElementSibling` would be null for a <thead> header).
+  const firstDataRow = bodyRows(ctx.table)[0] ?? null;
   if (firstDataRow) {
     firstDataRow.insertBefore(cell, firstDataRow.firstChild);
   } else {

--- a/src/enrichments/slider-threshold.ts
+++ b/src/enrichments/slider-threshold.ts
@@ -6,6 +6,7 @@
 
 import { createSliderControl, formatNumber } from '../ui/slider-control';
 import { parseHeaderNumber } from '../utils/sync-key';
+import { bodyRows, gridCells, cellValue } from '../core/table-grid';
 import { resolveInitialPosition, persistPosition, pruneEntry } from '../utils/slider-persistence';
 import { isEnrichmentEnabled } from '../core/enabled-set-state';
 import type { GridSightSlider } from './slider';
@@ -22,11 +23,9 @@ const thresholdSliders: { table: HTMLTableElement; slider: GridSightSlider }[] =
 
 function readNumericValuesFromTable(table: HTMLTableElement): number[] {
   const out: number[] = [];
-  for (let i = 1; i < table.rows.length; i++) {
-    const row = table.rows[i];
-    for (let j = 1; j < row.cells.length; j++) {
-      const t = row.cells[j].textContent?.trim() ?? '';
-      const n = parseHeaderNumber(t);
+  for (const row of bodyRows(table)) {
+    for (const cell of gridCells(row).slice(1)) {
+      const n = parseHeaderNumber(cellValue(cell));
       if (n !== null && isFinite(n)) out.push(n);
     }
   }
@@ -53,13 +52,10 @@ export function addThresholdSlider(table: HTMLTableElement): GridSightSlider {
   // Tag every numeric cell with its data-value so we can fade in CSS.
   // Also mark the host container.
   const host = ensureThresholdHost(table);
-  for (let i = 1; i < table.rows.length; i++) {
-    const row = table.rows[i];
-    for (let j = 1; j < row.cells.length; j++) {
-      const cell = row.cells[j];
+  for (const row of bodyRows(table)) {
+    for (const cell of gridCells(row).slice(1)) {
       if (cell.hasAttribute('data-gs-cell-value')) continue;
-      const t = cell.textContent?.trim() ?? '';
-      const n = parseHeaderNumber(t);
+      const n = parseHeaderNumber(cellValue(cell));
       if (n !== null && isFinite(n)) {
         cell.setAttribute('data-gs-cell-value', String(n));
       }

--- a/src/enrichments/sort.ts
+++ b/src/enrichments/sort.ts
@@ -7,14 +7,18 @@
 
 import { cleanNumericCell, type ColumnType } from '../core/type-detection';
 import { registerComparatorFactory, type SortDirective } from '../utils/visible-rows';
+import { gridCells, columnCells, cellValue } from '../core/table-grid';
 
 const collator = new Intl.Collator(undefined, { sensitivity: 'base', numeric: true });
 
 export type SortColumnType = 'numeric' | 'categorical';
 
+/** Read the logical column `columnIndex` of `row` as author data text — via the
+ *  canonical addressing layer, so a row slider's injected cell never shifts the
+ *  index and injected UI never pollutes the value (spec 013). */
 function readCellAt(row: HTMLTableRowElement, columnIndex: number): string {
-  const cell = row.cells[columnIndex];
-  return cell ? (cell.textContent ?? '').trim() : '';
+  const cell = gridCells(row)[columnIndex];
+  return cell ? cellValue(cell) : '';
 }
 
 /** Build a comparator for a (column, direction, columnType) tuple. */
@@ -55,13 +59,10 @@ export function detectSortColumnType(
   table: HTMLTableElement,
   columnIndex: number
 ): SortColumnType {
-  const tbody = table.tBodies[0];
-  if (!tbody) return 'categorical';
-  for (const row of Array.from(tbody.rows)) {
-    const v = (row.cells[columnIndex]?.textContent ?? '').trim();
+  for (const cell of columnCells(table, columnIndex)) {
+    const v = cellValue(cell);
     if (!v) continue;
-    if (cleanNumericCell(v) !== null) return 'numeric';
-    return 'categorical';
+    return cleanNumericCell(v) !== null ? 'numeric' : 'categorical';
   }
   return 'categorical';
 }

--- a/src/enrichments/sparkline-column.ts
+++ b/src/enrichments/sparkline-column.ts
@@ -13,6 +13,7 @@ import type {
 import { cleanNumericCell } from '../core/type-detection';
 import { registerRenderer, getNumericColumns, getColumnKeys } from './virtual-column';
 import { buildSparklineSvg, updateSparklineSvg } from './sparkline-svg';
+import { sourceCells, cellValue } from '../core/table-grid';
 
 function getNumericColumnIndices(directive: SparklineDirective): number[] {
   const keys = getColumnKeys(directive.tableEl);
@@ -25,9 +26,10 @@ function getNumericColumnIndices(directive: SparklineDirective): number[] {
 }
 
 function rowValues(row: HTMLTableRowElement, indices: number[]): Array<number | null> {
+  const cells = sourceCells(row);
   return indices.map((i) => {
-    if (i < 0 || i >= row.cells.length) return null;
-    return cleanNumericCell(row.cells[i]?.textContent ?? '');
+    if (i < 0 || i >= cells.length) return null;
+    return cleanNumericCell(cellValue(cells[i]));
   });
 }
 
@@ -42,9 +44,12 @@ function rowStats(values: Array<number | null>): { min: number | null; max: numb
 }
 
 function maxAbsAcross(rowEl: HTMLTableRowElement, indices: number[]): number {
+  const cells = sourceCells(rowEl);
   let max = 0;
   for (const i of indices) {
-    const v = cleanNumericCell(rowEl.cells[i]?.textContent ?? '');
+    const cell = cells[i];
+    if (!cell) continue;
+    const v = cleanNumericCell(cellValue(cell));
     if (v !== null && isFinite(v)) max = Math.max(max, Math.abs(v));
   }
   return max;

--- a/src/enrichments/virtual-column.ts
+++ b/src/enrichments/virtual-column.ts
@@ -30,6 +30,13 @@ import {
   type PersistedVirtualColumnState,
 } from './virtual-column-persistence';
 import { extractTableData, detectColumnTypes } from '../core/type-detection';
+import {
+  headerRow as gridHeaderRow,
+  sourceCells,
+  gridCells,
+  isScaffold,
+  cellValue,
+} from '../core/table-grid';
 
 interface TableContext {
   tableEl: HTMLTableElement;
@@ -64,9 +71,11 @@ export const registerVirtualColumn = registerRenderer;
 
 function deriveTableKey(table: HTMLTableElement): string {
   if (table.id) return table.id;
-  // Fallback: derive from header text hash. Keep simple/short.
-  const head = table.tHead?.rows[0];
-  const headers = head ? Array.from(head.cells).map((c) => c.textContent?.trim() || '') : [];
+  // Fallback: derive from header text hash. Keep simple/short. Read author
+  // source headers via the addressing layer so slider scaffolding / virtual
+  // columns never perturb the key (spec 013).
+  const head = gridHeaderRow(table);
+  const headers = head ? sourceCells(head).map((c) => cellValue(c)) : [];
   let hash = 0;
   const s = headers.join('|');
   for (let i = 0; i < s.length; i++) hash = (hash * 31 + s.charCodeAt(i)) | 0;
@@ -74,12 +83,12 @@ function deriveTableKey(table: HTMLTableElement): string {
 }
 
 function buildColumnKeys(table: HTMLTableElement): string[] {
-  const head = table.tHead?.rows[0];
+  const head = gridHeaderRow(table);
   if (!head) return [];
   const seen = new Map<string, number>();
   const keys: string[] = [];
-  Array.from(head.cells).forEach((cell) => {
-    const slug = slugifyColumnKey(cell.textContent || '') || 'col';
+  sourceCells(head).forEach((cell) => {
+    const slug = slugifyColumnKey(cellValue(cell)) || 'col';
     const n = seen.get(slug) ?? 0;
     seen.set(slug, n + 1);
     keys.push(n === 0 ? slug : `${slug}-${n + 1}`);
@@ -220,18 +229,20 @@ function appendCellsForDirective(
   const bodyCells = new Map<HTMLTableRowElement, HTMLTableCellElement>();
   const footerCells: HTMLTableCellElement[] = [];
 
-  // Header
+  // Header — first header row carries the label, spacer cells on others.
   const thead = table.tHead;
   if (thead) {
+    let firstHeader = true;
     for (let i = 0; i < thead.rows.length; i++) {
       const row = thead.rows[i];
+      if (isScaffold(row)) continue;
       const th = document.createElement('th');
       th.setAttribute('scope', 'col');
       th.setAttribute('data-gs-virtual-column', directive.kind);
       th.setAttribute('data-gs-virtual-column-id', directive.id);
-      // Only put header text on the first header row; spacer cells on others.
-      if (i === 0) {
+      if (firstHeader) {
         th.textContent = renderer.headerText(directive);
+        firstHeader = false;
       }
       insertCellAt(row, th, insertBeforeIdx);
       headerCells.push(th);
@@ -245,6 +256,7 @@ function appendCellsForDirective(
     const sequence = subscription.current();
     for (let i = 0; i < tbody.rows.length; i++) {
       const row = tbody.rows[i];
+      if (isScaffold(row)) continue;
       const td = document.createElement('td');
       td.setAttribute('data-gs-virtual-column', directive.kind);
       td.setAttribute('data-gs-virtual-column-id', directive.id);
@@ -265,6 +277,7 @@ function appendCellsForDirective(
   if (tfoot) {
     for (let i = 0; i < tfoot.rows.length; i++) {
       const row = tfoot.rows[i];
+      if (isScaffold(row)) continue;
       const td = document.createElement('td');
       td.setAttribute('data-gs-virtual-column', directive.kind);
       td.setAttribute('data-gs-virtual-column-id', directive.id);
@@ -282,15 +295,21 @@ function appendCellsForDirective(
   };
 }
 
+/** Insert `cell` at LOGICAL grid column `index` of `row`. The reference is the
+ *  grid cell currently occupying that logical slot (resolved via the addressing
+ *  layer, so injected scaffolding cells don't shift it); null ⇒ append at the
+ *  right edge. Keeps virtual columns in canonical order and correctly placed
+ *  even when a row slider has injected a leading cell (spec 013). */
 function insertCellAt(
   row: HTMLTableRowElement,
   cell: HTMLTableCellElement,
   index: number,
 ): void {
-  if (index >= row.cells.length) {
-    row.appendChild(cell);
+  const ref = gridCells(row)[index] ?? null;
+  if (ref) {
+    row.insertBefore(cell, ref);
   } else {
-    row.insertBefore(cell, row.cells[index]);
+    row.appendChild(cell);
   }
 }
 

--- a/src/ui/__tests__/header-utils.slider-placement.test.ts
+++ b/src/ui/__tests__/header-utils.slider-placement.test.ts
@@ -12,6 +12,12 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { injectPlusIcons } from '../header-utils';
 import { addSlider, removeAllSliders } from '../../enrichments/slider';
 import { setPageConfig, setVisitorOverride } from '../../core/enabled-set-state';
+import { gridCells, headerCellFor, headerRow as gridHeaderRow } from '../../core/table-grid';
+import {
+  buildNumericGrid,
+  activateInOrder,
+  type ActivationStep,
+} from '../../core/__tests__/helpers/grid-fixture';
 
 beforeEach(() => {
   document.body.innerHTML = '';
@@ -84,4 +90,40 @@ describe('lozenge placement with an active slider', () => {
       expect(injected.querySelector('[data-gs-lozenge-id]')).toBeNull();
     }
   });
+});
+
+/**
+ * Spec 013 US2: lozenges address the correct logical column and sit only on
+ * author cells regardless of the order sliders + virtual columns were added.
+ */
+describe('lozenge placement is order-independent (spec 013)', () => {
+  const ORDERS: ActivationStep[][] = [
+    ['cumulative', 'row', 'col'], // enrichment-first
+    ['row', 'col', 'cumulative'], // slider-first
+  ];
+
+  for (const order of ORDERS) {
+    it(`addresses the correct column after [${order.join(', ')}]`, () => {
+      const { table, sourceCols } = buildNumericGrid();
+      activateInOrder(table, order);
+      injectPlusIcons(table, ['numeric', 'numeric', 'numeric', 'numeric']);
+
+      // Every lozenge lives on a non-injected (author or virtual) cell.
+      for (const loz of Array.from(table.querySelectorAll<HTMLElement>('[data-gs-lozenge-id]'))) {
+        const host = loz.closest('th, td');
+        expect(host).not.toBeNull();
+        expect(host!.hasAttribute('data-gs-injected')).toBe(false);
+      }
+
+      // The statistics (#) lozenge for each source column header sits on the
+      // author header cell that the addressing layer resolves for that column.
+      const head = gridHeaderRow(table)!;
+      const headerCells = gridCells(head);
+      for (let k = 1; k < sourceCols; k++) {
+        const authorHeader = headerCellFor(table, k)!;
+        expect(authorHeader).toBe(headerCells[k]);
+        expect(authorHeader.querySelector('[data-gs-lozenge-id="statistics"]')).not.toBeNull();
+      }
+    });
+  }
 });

--- a/src/ui/header-utils.ts
+++ b/src/ui/header-utils.ts
@@ -15,6 +15,14 @@ import { createFilterLozenge } from './filter-lozenge';
 import { detectSortColumnType } from '../enrichments/sort';
 import { getEffectiveEnabledSet } from '../core/enabled-set-state';
 import { ensureRowVisibilityStyles } from './row-visibility-styles';
+import {
+  gridRows,
+  gridCells,
+  bodyRows,
+  columnCells,
+  cellValue,
+  logicalColIndexOf,
+} from '../core/table-grid';
 
 export type HeaderType = 'row' | 'column' | 'table';
 
@@ -25,31 +33,20 @@ const HEADER_WITH_ICON_CLASS = 'gs-has-plus-icon';
 const LOZENGE_CLASS = 'gs-lozenge';
 const LOZENGE_ACTIVE_CLASS = 'gs-lozenge--active';
 
-/** Rows/cells the slider enrichment injects carry `data-gs-injected`. Lozenge
- *  placement and column indexing must ignore them so that a column index always
- *  means "position among the original cells" — the same coordinate system the
- *  heatmap, sort, and filter consumers use. Without this, enabling a slider
- *  shifts every header's cell index and the lozenges land on the wrong cells. */
-function nonInjectedRows(table: HTMLTableElement): HTMLTableRowElement[] {
-  return Array.from(table.rows).filter(r => !r.hasAttribute('data-gs-injected'));
-}
-
-function nonInjectedCells(row: HTMLTableRowElement): HTMLTableCellElement[] {
-  return Array.from(row.cells).filter(c => !c.hasAttribute('data-gs-injected'));
-}
-
 /** Inject the inline lozenge toggles (H/S/#) on every applicable header.
- *  Replaces the previous "+ → dropdown" UX. */
+ *  Replaces the previous "+ → dropdown" UX. Column/row indexing goes through
+ *  the canonical addressing layer so slider scaffolding never displaces a
+ *  lozenge (spec 013). */
 export function injectPlusIcons(table: HTMLTableElement, columnTypes: ColumnType[]): void {
   removePlusIcons(table);
   ensureLozengeStyles();
   ensureRowVisibilityStyles();
 
-  const rows = nonInjectedRows(table);
+  const rows = gridRows(table);
   const headerRow = rows[0];
   if (!headerRow) return;
 
-  nonInjectedCells(headerRow).forEach((cell, colIndex) => {
+  gridCells(headerRow).forEach((cell, colIndex) => {
     const isTopLeftCell = colIndex === 0;
     const type = columnTypes[colIndex];
     if (type === 'numeric' || type === 'categorical') {
@@ -58,7 +55,7 @@ export function injectPlusIcons(table: HTMLTableElement, columnTypes: ColumnType
   });
 
   for (let i = 1; i < rows.length; i++) {
-    const cells = nonInjectedCells(rows[i]);
+    const cells = gridCells(rows[i]);
     if (!cells.length) continue;
     addLozengesToHeader(table, cells[0], 'row', 0);
   }
@@ -95,14 +92,7 @@ interface LozengeSpec {
 /** Detect whether a body cell in this column spans more than one row — if so,
  *  sort and filter are suppressed (per spec edge cases). */
 function columnHasRowspanBodyCells(table: HTMLTableElement, columnIndex: number): boolean {
-  const tbody = table.tBodies[0];
-  if (!tbody) return false;
-  for (const row of Array.from(tbody.rows)) {
-    if (row.hasAttribute('data-gs-injected')) continue;
-    const cell = nonInjectedCells(row)[columnIndex];
-    if (cell && cell.rowSpan > 1) return true;
-  }
-  return false;
+  return columnCells(table, columnIndex).some(cell => cell.rowSpan > 1);
 }
 
 function addLozengesToHeader(
@@ -330,55 +320,46 @@ function inferHeaderColumnType(
   type: HeaderType
 ): ColumnType {
   if (type === 'column') {
-    const headerRow = header.closest('tr');
-    if (headerRow) {
-      const colIndex = nonInjectedCells(headerRow).indexOf(header);
-      const firstDataRow = nonInjectedRows(table)[1];
-      const dataCell = firstDataRow ? nonInjectedCells(firstDataRow)[colIndex] : undefined;
+    const colIndex = logicalColIndexOf(header);
+    if (colIndex >= 0) {
+      const dataCell = columnCells(table, colIndex)[0];
       if (dataCell) {
-        const value = dataCell.textContent?.trim() ?? '';
-        return cleanNumericCell(value) !== null ? 'numeric' : 'categorical';
+        return cleanNumericCell(cellValue(dataCell)) !== null ? 'numeric' : 'categorical';
       }
     }
     return 'categorical';
   }
   if (type === 'row') {
-    const row = header.closest('tr');
+    const row = header.closest('tr') as HTMLTableRowElement | null;
     if (row) {
-      const hasNumeric = nonInjectedCells(row).slice(1).some(cell => {
-        const v = cell.textContent?.trim() ?? '';
-        return cleanNumericCell(v) !== null;
-      });
+      const hasNumeric = gridCells(row).slice(1).some(cell =>
+        cleanNumericCell(cellValue(cell)) !== null
+      );
       return hasNumeric ? 'numeric' : 'categorical';
     }
     return 'categorical';
   }
   // type === 'table'
-  const rows = nonInjectedRows(table).slice(1);
-  const hasNumeric = rows.some(row =>
-    nonInjectedCells(row).some(cell => {
-      const v = cell.textContent?.trim() ?? '';
-      return cleanNumericCell(v) !== null;
-    })
+  const hasNumeric = bodyRows(table).some(row =>
+    gridCells(row).some(cell => cleanNumericCell(cellValue(cell)) !== null)
   );
   return hasNumeric ? 'numeric' : 'categorical';
 }
 
 function inferHeaderType(header: HTMLTableCellElement): HeaderType {
-  const row = header.closest('tr');
-  const tbl = header.closest('table');
+  const row = header.closest('tr') as HTMLTableRowElement | null;
+  const tbl = header.closest('table') as HTMLTableElement | null;
   if (!row || !tbl) return 'column';
-  const isFirstRow = row === tbl.rows[0];
-  const isFirstCell = header === row.cells[0];
+  const isFirstRow = row === gridRows(tbl)[0];
+  const isFirstCell = header === gridCells(row)[0];
   if (isFirstRow && isFirstCell) return 'table';
   if (isFirstRow) return 'column';
   return 'row';
 }
 
 function headerColIndex(header: HTMLTableCellElement): number {
-  const row = header.closest('tr');
-  if (!row) return 0;
-  return Array.from(row.cells).indexOf(header);
+  const idx = logicalColIndexOf(header);
+  return idx < 0 ? 0 : idx;
 }
 
 function heatmapTitle(type: HeaderType): string {
@@ -409,8 +390,7 @@ function isCurrentHeatmapActive(
   if (type === 'row') {
     const tr = header.closest('tr') as HTMLTableRowElement | null;
     if (!tr) return false;
-    const ri = Array.from(tr.parentElement?.children || []).indexOf(tr);
-    return isHeatmapActive(table, ri + 1, 'row');
+    return isHeatmapActive(table, heatmapRowIndex(table, tr), 'row');
   }
   return isHeatmapActive(table, -1, 'table');
 }
@@ -426,11 +406,17 @@ function applyHeatmapToggle(
   } else if (type === 'row') {
     const tr = header.closest('tr') as HTMLTableRowElement | null;
     if (!tr) return;
-    const ri = Array.from(tr.parentElement?.children || []).indexOf(tr);
-    toggleHeatmap(table, ri + 1, 'row');
+    toggleHeatmap(table, heatmapRowIndex(table, tr), 'row');
   } else {
     toggleHeatmap(table, -1, 'table');
   }
+}
+
+/** 1-based body-row position used as the heatmap "row" key. Derived from
+ *  bodyRows so slider scaffolding never shifts it; matches the index
+ *  `heatmap.ts::collectRowCells` resolves via `bodyRows[index - 1]`. */
+function heatmapRowIndex(table: HTMLTableElement, tr: HTMLTableRowElement): number {
+  return bodyRows(table).indexOf(tr) + 1;
 }
 
 function sliderApplicable(table: HTMLTableElement, type: HeaderType): boolean {
@@ -484,6 +470,7 @@ function dispatchEnrichmentEvent(
   enrichmentType: string,
   colIndex: number
 ): void {
+  const table = header.closest('table') as HTMLTableElement | null;
   const event = new CustomEvent('gridsight:enrichmentSelected', {
     bubbles: true,
     detail: {
@@ -492,8 +479,8 @@ function dispatchEnrichmentEvent(
       header,
       headerIndex: type === 'column'
         ? colIndex
-        : type === 'row'
-          ? Array.from(header.closest('tr')?.parentElement?.children ?? []).indexOf(header.closest('tr') as HTMLTableRowElement)
+        : type === 'row' && table
+          ? bodyRows(table).indexOf(header.closest('tr') as HTMLTableRowElement)
           : 0,
     },
   });

--- a/src/ui/toggle-injector.ts
+++ b/src/ui/toggle-injector.ts
@@ -8,6 +8,14 @@ import { addThresholdSlider } from '../enrichments/slider-threshold';
 import { calculateStatistics } from '../enrichments/statistics';
 import { analyzeFrequencies } from '../utils/frequency';
 import { cleanNumericCell } from '../core/type-detection';
+import {
+  columnCells,
+  gridCells,
+  bodyRows,
+  cellValue,
+  logicalColIndexOf,
+  logicalRowIndexOf,
+} from '../core/table-grid';
 import { StatisticsPopup } from './statistics-popup';
 import { FrequencyDialog } from './frequency-dialog';
 import { FrequencyChartDialog } from './frequency-chart-dialog';
@@ -127,17 +135,17 @@ function handleEnrichmentSelected(event: Event) {
   }
   if (enrichmentType === 'heatmap') {
     if (type === 'column') {
-      // Type assertion for table header cell
-      const th = header as HTMLTableCellElement;
-      const columnIndex = th.cellIndex;
+      // Logical column index via the addressing layer (not th.cellIndex, which
+      // shifts when a slider injects cells).
+      const columnIndex = logicalColIndexOf(header as HTMLTableCellElement);
       if (columnIndex >= 0) {
         toggleHeatmap(table, columnIndex, 'column');
       }
     } else if (type === 'row') {
-      // Get the row index (0-based) and add 1 to make it 1-based for CSS nth-child
-      const rowIndex = Array.from(header.closest('tr')?.parentElement?.children || []).indexOf(header.closest('tr') as HTMLTableRowElement);
+      // 1-based body-row position (matches heatmap.ts::collectRowCells).
+      const tr = header.closest('tr') as HTMLTableRowElement | null;
+      const rowIndex = tr ? bodyRows(table).indexOf(tr) : -1;
       if (rowIndex >= 0) {
-        // Add 1 to make the index 1-based for CSS nth-child selector
         toggleHeatmap(table, rowIndex + 1, 'row');
       }
     } else if (type === 'table') {
@@ -204,45 +212,37 @@ function handleEnrichmentSelected(event: Event) {
       if (type === 'column') {
         // Type assertion for table header cell
         const th = header as HTMLTableCellElement;
-        // `headerIndex` is the column's position among non-injected cells, so it
-        // stays aligned with the clicked column when a slider has injected cells.
+        // `headerIndex` is the logical column index (from header-utils), aligned
+        // with the clicked column regardless of slider injection.
         const columnIndex = headerIndex;
         if (columnIndex < 0) {
           throw new Error('Invalid column index');
         }
 
-        // Get all cell values from the column, excluding the header row and
-        // any slider-injected rows/cells.
-        const rows = Array.from(table.rows).filter(r => !r.hasAttribute('data-gs-injected'));
-        values = rows
-          .filter((_, rowIndex) => rowIndex > 0) // Skip the header row
-          .map(row => {
-            const cell = Array.from(row.cells).filter(c => !c.hasAttribute('data-gs-injected'))[columnIndex];
-            return cell ? cell.textContent || '' : '';
-          });
+        // Author values for the logical column, injected UI stripped.
+        values = columnCells(table, columnIndex).map(cellValue);
 
         // Get column name
-        itemName = th.textContent?.trim() || `Column ${columnIndex + 1}`;
+        itemName = cellValue(th) || `Column ${columnIndex + 1}`;
       } else if (type === 'row') {
         // Type assertion for table row
         const tr = header.closest('tr') as HTMLTableRowElement;
         if (!tr) {
           throw new Error('Could not find row');
         }
-        
-        // Get row index
-        const rowIndex = tr.rowIndex;
-        
-        // Get all cell values from the row, excluding the first cell if it's a header
-        const cells = Array.from(tr.cells);
+
+        // Logical row identity (stable across sort) for the label.
+        const rowIndex = logicalRowIndexOf(table, tr);
+
+        // Author values for the row, excluding the leading row-header cell.
+        const cells = gridCells(tr);
         const startIndex = cells.length > 0 && cells[0].tagName.toLowerCase() === 'th' ? 1 : 0;
-        
-        values = cells.slice(startIndex).map(cell => cell.textContent || '');
-        
+        values = cells.slice(startIndex).map(cellValue);
+
         // Get row name/identifier (typically first cell or row number)
-        itemName = cells.length > 0 ? 
-          (cells[0].textContent?.trim() || `Row ${rowIndex + 1}`) : 
-          `Row ${rowIndex + 1}`;
+        itemName = cells.length > 0
+          ? (cellValue(cells[0]) || `Row ${rowIndex + 1}`)
+          : `Row ${rowIndex + 1}`;
       } else {
         throw new Error('Unsupported enrichment target type');
       }
@@ -299,23 +299,10 @@ function handleEnrichmentSelected(event: Event) {
  */
 function extractNumericColumnValues(table: HTMLTableElement, columnIndex: number): number[] {
   const values: number[] = [];
-
-  // Get all rows in the tbody, skipping slider-injected rows/cells so that
-  // `columnIndex` refers to the column's position among the original cells.
-  const rows = table.tBodies[0]?.rows || [];
-
-  for (let i = 0; i < rows.length; i++) {
-    if (rows[i].hasAttribute('data-gs-injected')) continue;
-    const cells = Array.from(rows[i].cells).filter(c => !c.hasAttribute('data-gs-injected'));
-    const cell = cells[columnIndex];
-    if (!cell) continue;
-
-    const value = cleanNumericCell(cell.textContent || '');
-    if (value !== null) {
-      values.push(value);
-    }
+  for (const cell of columnCells(table, columnIndex)) {
+    const value = cleanNumericCell(cellValue(cell));
+    if (value !== null) values.push(value);
   }
-
   return values;
 }
 
@@ -324,58 +311,35 @@ function extractNumericColumnValues(table: HTMLTableElement, columnIndex: number
  */
 function extractNumericRowValues(row: HTMLTableRowElement): number[] {
   const values: number[] = [];
+  const cells = gridCells(row);
 
-  // Get all cells in the row, excluding slider-injected cells.
-  const cells = Array.from(row.cells).filter(c => !c.hasAttribute('data-gs-injected'));
-
-  // Skip the first cell if it's a header
+  // Skip the first cell if it's a row header.
   const startIndex = cells.length > 0 && cells[0].tagName.toLowerCase() === 'th' ? 1 : 0;
-  
+
   for (let i = startIndex; i < cells.length; i++) {
-    const value = cleanNumericCell(cells[i].textContent || '');
-    if (value !== null) {
-      values.push(value);
-    }
+    const value = cleanNumericCell(cellValue(cells[i]));
+    if (value !== null) values.push(value);
   }
-  
+
   return values;
 }
 
 /**
- * Extracts all numeric values from a table, excluding headers
+ * Extracts all numeric values from a table body, excluding headers
  */
 function extractNumericTableValues(table: HTMLTableElement): number[] {
   const values: number[] = [];
 
-  // Get all rows in the table, excluding slider-injected rows.
-  const rows = Array.from(table.rows).filter(r => !r.hasAttribute('data-gs-injected'));
-
-  // Skip the header row(s)
-  // If there's a thead, skip all (non-injected) rows in it
-  // Otherwise, skip the first row as it's likely a header
-  const startIndex = table.tHead
-    ? Array.from(table.tHead.rows).filter(r => !r.hasAttribute('data-gs-injected')).length
-    : 1;
-
-  // Process all non-header rows
-  for (let i = startIndex; i < rows.length; i++) {
-    const row = rows[i];
-
-    // Get all cells in the row, excluding slider-injected cells.
-    const cells = Array.from(row.cells).filter(c => !c.hasAttribute('data-gs-injected'));
-
-    // Skip the first cell if it's a header
+  for (const row of bodyRows(table)) {
+    const cells = gridCells(row);
+    // Skip the first cell if it's a row header.
     const cellStartIndex = cells.length > 0 && cells[0].tagName.toLowerCase() === 'th' ? 1 : 0;
-    
-    // Process all non-header cells
     for (let j = cellStartIndex; j < cells.length; j++) {
-      const value = cleanNumericCell(cells[j].textContent || '');
-      if (value !== null) {
-        values.push(value);
-      }
+      const value = cleanNumericCell(cellValue(cells[j]));
+      if (value !== null) values.push(value);
     }
   }
-  
+
   return values;
 }
 

--- a/src/utils/view-state-url.ts
+++ b/src/utils/view-state-url.ts
@@ -14,6 +14,7 @@ import type {
   TableViewDirective,
 } from './visible-rows';
 import { decodeViewState } from './view-state-decode';
+import { headerRow, gridCells } from '../core/table-grid';
 export { decodeViewState };
 
 const URL_FRAGMENT_PARAM = 'gs.v';
@@ -30,10 +31,8 @@ export function colKey(header: HTMLTableCellElement, columnIndex: number): strin
  *  Slider-injected rows/cells (`data-gs-injected`) are skipped so `columnIndex`
  *  means the same thing whether or not a slider is active. */
 export function colKeyAt(table: HTMLTableElement, columnIndex: number): string {
-  const headerRow = Array.from(table.rows).find(r => !r.hasAttribute('data-gs-injected'));
-  const cells = headerRow
-    ? Array.from(headerRow.cells).filter(c => !c.hasAttribute('data-gs-injected'))
-    : [];
+  const head = headerRow(table);
+  const cells = head ? gridCells(head) : [];
   if (!cells[columnIndex]) return `c${columnIndex}`;
   return colKey(cells[columnIndex], columnIndex);
 }


### PR DESCRIPTION
Add src/core/table-grid.ts as the sole authority for translating between
logical (row, column) coordinates and physical live-DOM cells. It derives
everything from the live DOM + existing markers at call time (stateless,
no new DOM/markers), so results depend only on current state, never on
enrichment activation order.

Migrate all physical-index consumers onto it — sort, filter, frequency,
heatmap, header-utils lozenge placement, toggle-injector statistics/
frequency sites, slider axis-binding, virtual-column key derivation +
insertion, value extraction (sparkline/compare/cumulative/threshold),
and column-type detection — collapsing the duplicated nonInjected* helpers.
cellValue strips injected Grid-Sight UI so author values stay clean.

Locks correctness in with a composition matrix run in both activation
orders plus per-primitive unit tests (INV-1..INV-8 / SC-001..SC-003).

https://claude.ai/code/session_01CXRJUbYpyVspkw2nB9hHCw