### PR TITLE
Spec 015: Welcome page redesign & per-table options

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/014-navigation-and-analysis"
+  "feature_directory": "specs/015-welcome-per-table-options"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-[specs/014-navigation-and-analysis/plan.md](specs/014-navigation-and-analysis/plan.md)
+[specs/015-welcome-per-table-options/plan.md](specs/015-welcome-per-table-options/plan.md)
 <!-- SPECKIT END -->

--- a/specs/015-welcome-per-table-options/checklists/requirements.md
+++ b/specs/015-welcome-per-table-options/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Welcome Page Redesign & Per-Table Options
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.
+- Two assumptions were made that planning should confirm rather than re-open:
+  (1) the interaction between the global enable control and per-table
+  start-state, and (2) last-match-wins for overlapping per-table selectors.
+  Both are documented in the spec's Assumptions section with unambiguous
+  visible behaviour, so they do not block planning, but `/speckit-clarify`
+  is a reasonable next step if you want them locked down before `/speckit-plan`.

--- a/specs/015-welcome-per-table-options/contracts/per-table-options.md
+++ b/specs/015-welcome-per-table-options/contracts/per-table-options.md
@@ -1,0 +1,105 @@
+# Contract — Per-Table Options
+
+Module surface and behavioural contract for the per-table configuration
+capability. Consumers: host pages (config), `header-utils` + `index.ts`
+(gating), `toggle-injector` (start-state).
+
+## 1. Author config contract
+
+Declared on the existing config object — **no change to `window.gridSight.init`'s
+signature**:
+
+```js
+window.gridSight.pageConfig = {
+  enrichments: ['heatmap', 'sort', 'sliders', /* … */], // existing page-level (optional)
+  tables: [
+    { selector: '#heatmap-demo', enrichments: ['heatmap'], startActive: true },
+    { selector: '#sort-demo',    enrichments: ['sort', 'filter'], startActive: true },
+    { selector: '.lookup',       enrichments: ['sliders', 'statistics'] },        // startActive defaults false
+    { selector: '#raw-first',    enrichments: ['heatmap'], startActive: false },  // demonstrates default-off
+  ],
+};
+```
+
+Equivalent ESM path: `gridSight.init({ tables: [ … ] })`.
+
+### Field rules
+
+| Field | Required | Default | Normalisation |
+|-------|----------|---------|---------------|
+| `selector` | yes | — | used as-authored; matched via `Element.matches` against `<table>`s |
+| `enrichments` | no | (fall through to page-level) | trim + lowercase + dedup; non-strings dropped (one warning) |
+| `startActive` | no | `false` | `Boolean()`-coerced if non-boolean (one warning) |
+
+### Malformed input (never throws into host page)
+
+- `tables` not an array → warn once, ignored.
+- entry without a non-empty string `selector` → dropped, warn once.
+- unknown enrichment ids → dropped at resolution (no warning required; mirrors page-level).
+
+## 2. Resolution contract
+
+For a given table `T` not marked `data-gs-ignore`:
+
+```text
+entries(T)     = pageConfig.tables in declaration order where T matches entry.selector
+folded(T)      = fold entries(T) with LAST-MATCH-WINS per field (enrichments, startActive)
+
+enabledSet(T)  =
+   visitorOverride ≠ ∅  → intersect(visitorOverride, knownIds)      // visitor wins
+   else folded.enrichments defined → intersect(folded.enrichments, knownIds)
+   else pageConfig.enrichments defined → intersect(pageConfig.enrichments, knownIds)
+   else { e.id | e ∈ registry, e.defaultOn }
+
+startActive(T) = folded.startActive ?? false
+```
+
+Precedence (FR-016): **visitor > per-table > page > defaults**. Unknown ids
+dropped at every tier (FR-017). A table matched by no entry → `enabledSet(T)`
+equals the current page-global resolution (INV-1, FR-018).
+
+## 3. Gate surface (table-aware, backward compatible)
+
+```ts
+// src/core/enabled-set-state.ts
+getEffectiveEnabledSet(table?: HTMLTableElement): ReadonlySet<string>
+isEnrichmentEnabled(id: string, table?: HTMLTableElement): boolean
+```
+
+- Omitting `table` (or passing an unmatched table) → page-global set (unchanged).
+- Passing a matched table → that table's resolved set.
+- Results cached per table in a `WeakMap`; cache rebuilt on `setPageConfig` /
+  `setVisitorOverride` / global re-enable.
+
+Callers updated to pass the table where the decision is table-scoped:
+`header-utils.addLozengesToHeader` (has `table`), and `index.ts` gates for
+`outlier` / `freeze-panes` / `summary-row`.
+
+## 4. Start-state surface
+
+```ts
+// src/ui/toggle-injector.ts (extracted from the existing inline click handler)
+activateToggle(table: HTMLTableElement): void    // reveal enrichments: add active class, aria-expanded=true, inject plus-icons, wire listener
+deactivateToggle(table: HTMLTableElement): void  // hide: remove active class, aria-expanded=false, remove plus-icons + listener
+```
+
+- The GS toggle's `click` handler calls these (same code path as a manual click).
+- `index.ts`, after `injectToggle(table)`, calls `activateToggle(table)` iff
+  `resolveTableConfig(table).startActive`.
+- Contract: `deactivateToggle` after any `activateToggle` restores
+  byte-identical original markup (INV-4 / FR-024).
+
+## 5. Acceptance mapping
+
+| Spec | Covered by |
+|------|-----------|
+| FR-014 (id/selector) | §1 selector, §2 entries(T) |
+| FR-015 (per-table enrichments) | §2 enabledSet(T) per-table branch |
+| FR-016 (precedence) | §2 ordering |
+| FR-017 (unknown ids dropped) | §2 `intersect(..., knownIds)` every tier |
+| FR-018 (no regression) | §2 no-match branch = page-global; INV-1 |
+| FR-019 (`data-gs-ignore` wins) | §2 precondition; R-8 |
+| FR-020/021 (start-state, default off) | §4; folded.startActive ?? false |
+| FR-022 (default unchanged) | §3 omit-table path; INV-3 |
+| FR-023 (deterministic multi-match) | §2 last-match-wins; R-7 |
+| FR-024 (teardown identity) | §4 shared path; INV-4 |

--- a/specs/015-welcome-per-table-options/contracts/welcome-page.md
+++ b/specs/015-welcome-per-table-options/contracts/welcome-page.md
@@ -1,0 +1,68 @@
+# Contract — Welcome Page (`public/index.html`)
+
+Structure and behaviour the rewritten welcome page MUST satisfy. This is a
+content/markup contract (no bundled runtime surface). Verified by Playwright
+(`e2e/welcome-per-table.spec.ts`) and by manual review.
+
+## Page order (top → bottom)
+
+1. **Hero + principles** (FR-001, FR-002)
+   - One-sentence plain-language statement of what Grid-Sight is.
+   - The problem it solves: enrich existing HTML tables in place, no rebuild.
+   - Principles, each in plain language: offline / air-gapped · zero runtime
+     dependencies · progressive enhancement · accessibility by default ·
+     read-only / byte-identical teardown.
+   - Readable with Grid-Sight disabled (the intro does not depend on any table).
+
+2. **Four feature sections** (FR-003, FR-004, FR-005, FR-006, FR-007, FR-008)
+   Each section:
+   - Heading + narrative explaining the feature area in warm, technical-but-plain
+     language.
+   - ≥ 1 **live** sample table addressed by `id` and configured via
+     `pageConfig.tables` to offer that area's enrichment(s).
+   - DOM order is **narrative then table**; visual side **alternates** between
+     consecutive sections via CSS only (tab/read order stays logical).
+   - Collapses to a single column under a mobile-width `@media` breakpoint with
+     no horizontal overflow.
+   - Links to the related existing demo page(s) for that area.
+   Areas: (a) Sliders & interpolation; (b) Visual analysis — heatmap, outlier,
+   statistics, summary row; (c) Navigation & search — sort, filter, find,
+   freeze panes; (d) Derived data & notes — virtual columns Σ/⌇/Δ, annotations.
+
+3. **Global toggle, explained** (FR-009, FR-010)
+   - Retains the "Grid-Sight enabled on this page" control.
+   - Narrative frames it as a non-destructive overlay: off ⇒ original tables
+     restored; on ⇒ re-enriched. Toggling does not reload the page.
+
+4. **Start-state demonstration** (FR-011)
+   - At least one inline table loads with its GS toggle **active** (enrichments
+     revealed) and at least one loads **inactive** (default), shown so the
+     contrast is visible; the visitor can flip either in place.
+
+5. **All-demos index** (FR-012)
+   - Links to all 12 existing demo pages; none orphaned.
+
+## Behavioural requirements
+
+- **Offline (FR-013, SC-007)**: page + IIFE + every inline demo function from a
+  `file://` load; no network requests at runtime (no fetched fonts/icons).
+- **Distinct sets co-resident (SC-005)**: at least two inline tables
+  simultaneously expose **different** enrichment sets, driven solely by
+  `pageConfig.tables`.
+- **Reference "before" table**: a plain table marked `data-gs-ignore` remains
+  raw regardless of any selector (illustrates opt-out; INV-5).
+- **Slider formula**: the sliders demo registers its formula once the IIFE loads
+  (as the current page does).
+
+## Accessibility (constitution §III)
+
+- Sections use semantic headings/landmarks; alternation is CSS `order` only so
+  the accessibility tree follows DOM order.
+- The GS toggle stays a keyboard-operable `<button>` with correct `aria-expanded`
+  in both start-states.
+- No colour-only signals introduced by the page chrome.
+
+## Out of scope
+
+- No new enrichment types; no scrollytelling/sticky JS (alternating rows chosen).
+- No change to the existing demo pages themselves (only linked).

--- a/specs/015-welcome-per-table-options/data-model.md
+++ b/specs/015-welcome-per-table-options/data-model.md
@@ -1,0 +1,123 @@
+# Phase 1 — Data Model
+
+Feature: Welcome Page Redesign & Per-Table Options
+Date: 2026-05-30
+
+The feature adds **config-time** entities (parsed from author input) and
+**derived runtime** entities (computed per table). Nothing is persisted (no new
+`gs:` key, no URL fragment). All types live in `src/core/`.
+
+---
+
+## Entity: `RawTableOptionEntry` (author input, pre-validation)
+
+What the host page writes inside `pageConfig.tables` (or `init({ tables })`).
+Shape is *advisory* — `parsePageConfig` validates/normalises it.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `selector` | string | **yes** | CSS selector (an `#id` is the common case). Matched against `<table>` elements at `init()`. |
+| `enrichments` | string[] | no | Ids this table offers. Absent → the table falls through to the page-level set for enrichments. Present (incl. `[]`) → replaces the offered set for matched tables. |
+| `startActive` | boolean | no | Whether the matched table's GS toggle begins active (enrichments revealed). Absent → `false` (default off). |
+
+**Validation (R-9, in `parsePageConfig`)**:
+- `tables` not an array → warn once, ignore the field.
+- entry not an object, or `selector` not a non-empty string → drop entry, warn once.
+- `enrichments` not an array → ignore that field (entry kept); non-string members dropped with one warning; members trimmed + lowercased + deduped.
+- `startActive` not boolean → `Boolean()`-coerce with one warning.
+
+---
+
+## Entity: `ParsedTableOptionEntry` (normalised)
+
+Produced by `parsePageConfig`; stored on the parsed config.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `selector` | string | non-empty, as authored (selectors are case-sensitive for attribute values; not lowercased). |
+| `enrichments` | `Set<string>` \| `undefined` | normalised ids, or `undefined` when the field was absent (distinct from an empty set = "offer none"). |
+| `startActive` | boolean | defaulted to `false`. |
+
+### Extension to `ParsedPageConfig`
+
+```text
+ParsedPageConfig {
+  enrichments: Set<string> | undefined   // existing (page-level)
+  showToggleUi: boolean                   // existing
+  tables: ParsedTableOptionEntry[]        // NEW — [] when absent
+}
+```
+
+---
+
+## Entity: `ResolvedTableConfig` (derived, per table, cached)
+
+Computed once per table at `init()` (and on global re-enable), cached in a
+`WeakMap<HTMLTableElement, ResolvedTableConfig>` in `enabled-set-state.ts` /
+`per-table-options.ts`.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `enrichments` | `Set<string>` | the effective enabled set for *this* table, after precedence resolution (visitor > per-table > page > defaults), unknown ids dropped. |
+| `startActive` | boolean | the effective GS-toggle start-state for this table. |
+| `matched` | boolean | whether any per-table entry matched (drives "fall back to global" vs "use per-table"). |
+
+**Derivation (per table)**:
+1. If `data-gs-ignore` → table is excluded before this runs (no entry).
+2. Match: collect entries whose `selector` matches the table (`Element.matches`),
+   in declaration order.
+3. Fold with **last-match-wins per field** (R-7): later `enrichments`/`startActive`
+   override earlier; absent fields leave prior value.
+4. `enrichments` set:
+   - visitor override present → `intersect(visitorOverride, knownIds)` (visitor wins, R-3);
+   - else folded per-table `enrichments` present → `intersect(that, knownIds)`;
+   - else page-level branch (existing `resolveEnabledSet` page/defaults logic).
+5. `startActive`: folded value, default `false`.
+
+---
+
+## Derived behaviour: table-aware gate
+
+`enabled-set-state.ts` surface (backward-compatible overloads):
+
+```text
+getEffectiveEnabledSet(table?: HTMLTableElement): ReadonlySet<string>
+isEnrichmentEnabled(id: string, table?: HTMLTableElement): boolean
+```
+
+- No `table`, or a table with `matched === false` → returns the page-global set
+  (today's behaviour; SC-009 / FR-018).
+- A matched table → returns its `ResolvedTableConfig.enrichments`.
+
+---
+
+## Welcome-page content entities (documentation-only, not code types)
+
+Captured for the `public/index.html` rewrite; see `contracts/welcome-page.md`.
+
+| Entity | Key parts |
+|--------|-----------|
+| **Intro/hero** | What GS is; problem it solves; principles (offline, no deps, progressive, accessible, byte-identical teardown). |
+| **Feature section** (×4) | Heading + narrative; ≥1 live demo table addressed by id in `pageConfig.tables`; links to that area's existing demo page(s); alternates side. |
+| **Global toggle region** | The retained enable/disable control + narrative explaining the non-destructive overlay. |
+| **Start-state demo** | One table `startActive: true` shown beside one `startActive: false`. |
+| **All-demos index** | Links to all 12 existing demo pages (zero orphaned). |
+
+---
+
+## Invariants
+
+- **INV-1 (no-regression)**: For any table with no matching entry, the resolved
+  enrichment set equals `resolveEnabledSet` with no per-table tier — byte-for-byte
+  today's behaviour.
+- **INV-2 (unknown-id drop)**: No `ResolvedTableConfig.enrichments` ever contains
+  an id absent from the registry, at any tier.
+- **INV-3 (default off)**: `startActive` defaults to `false`; a table without a
+  matching entry keeps today's inactive-on-load GS toggle.
+- **INV-4 (teardown identity)**: A `startActive: true` table, when its toggle is
+  deactivated (manually or via global disable), restores byte-identical original
+  markup — because the programmatic activate and the manual click share one path.
+- **INV-5 (opt-out absolute)**: `data-gs-ignore` tables receive no per-table
+  config and no GS UI.
+- **INV-6 (no persistence)**: Per-table options and start-state add no persisted
+  state; only author-declared config and transient in-DOM toggle state exist.

--- a/specs/015-welcome-per-table-options/plan.md
+++ b/specs/015-welcome-per-table-options/plan.md
@@ -1,0 +1,201 @@
+# Implementation Plan: Welcome Page Redesign & Per-Table Options
+
+**Branch**: `claude/welcome-page-redesign-rVjHn` (feature dir `015-welcome-per-table-options`) | **Date**: 2026-05-30 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/015-welcome-per-table-options/spec.md`
+
+## Summary
+
+Two bundled deliverables, one motivating the other:
+
+1. **Per-table options** — a new platform capability that lets a host page give
+   different tables on the same page different configurations, addressing each
+   table by **`id` or CSS selector**. Two things are scoped per table: the
+   **enrichment set** offered, and the **GS-toggle start-state** (whether the
+   table's "GS" corner toggle begins *active* — enrichments revealed — or
+   *inactive*, the default). The existing page-level config and the global
+   on/off behaviour are preserved; per-table is an additive tier with precedence
+   **visitor > per-table > page > library defaults**.
+
+2. **Welcome page redesign** — rebuild `public/index.html` from a sliders-demo
+   index into a broad, warm-but-technical introduction for first-time visitors:
+   a hero + principles intro, then four feature sections laid out as alternating
+   narrative/live-table rows (stacking on mobile), each demo table driven by the
+   per-table API to show only its feature and (mostly) start with enrichments
+   already revealed. The global enable/disable toggle stays, explained in the
+   narrative; the page also demonstrates the start-state option by showing a
+   table that starts inactive next to one that starts active. Links to all 12
+   existing demo pages are retained.
+
+The core engineering move is making the gate **table-aware**: today
+`isEnrichmentEnabled(id)` and `getEffectiveEnabledSet()` resolve a single
+page-global set (`src/core/enabled-set-state.ts`). This plan adds an optional
+table argument so the injection pass (`header-utils.addLozengesToHeader`, which
+already holds the table) and the auto-render gates in `index.ts` resolve the set
+*for that table*. With no per-table entry, resolution is byte-for-byte the
+current global behaviour (no regression). The GS-toggle start-state reuses the
+existing toggle activate/deactivate logic — extracted from the inline click
+handler in `toggle-injector.ts` into named functions — invoked once after
+`injectToggle` when a table's resolved start-state is active.
+
+## Technical Context
+
+**Language/Version**: TypeScript ~5.8 (project compiler; emits ES2020+).
+
+**Primary Dependencies**: **None new.** Pure DOM + existing core modules. CSS
+selector matching uses the native `Element.matches` / `document.querySelectorAll`
+(both > 2 years on every engine). No `shepherd.js`, no `simple-statistics`
+involvement in this feature.
+
+**Storage**: **None new.** Per-table options are author-declared config read at
+`init()` from `window.gridSight.pageConfig` (or `init(options)`); the start-state
+is a load-time initial position only — the visitor's subsequent GS-toggle clicks
+are transient in-DOM state exactly as today. No new `gs:` persistence key, no new
+URL fragment.
+
+**Testing**: Vitest unit tests (per-table resolver precedence, selector
+matching, config parsing/normalisation, start-state default), jsdom interaction
+tests (table-aware lozenge injection; programmatic toggle activation;
+byte-identical teardown), Storybook stories for the per-table demo composition,
+and Playwright e2e for the welcome page (two tables exposing different
+enrichments simultaneously; one start-active vs one start-inactive; global
+toggle round-trip; all demo links reachable; `file://` load). Existing suites
+remain the regression guard (SC-009).
+
+**Target Platform**: Evergreen browsers ≤ 2 years (constitution §V).
+`Element.matches`, `querySelectorAll`, `WeakMap`, CSS grid (alternating
+two-column layout, `@media` stacking) are all > 2 years on every engine — no
+feature detection required. Runs from `file://` and in jsdom under Vitest.
+
+**Project Type**: Browser library, single project. IIFE bundle
+(`dist/grid-sight.iife.js`) + npm/ESM. Adds per-table resolution to `src/core/`,
+threads a table argument through `src/ui/` injection, and refactors the toggle
+activate path in `src/ui/toggle-injector.ts`. The welcome page is a
+`public/index.html` rewrite (no new runtime surface). No addition to the frozen
+`window.gridSight.init` signature — `pageConfig.tables` is read from the existing
+config object.
+
+**Performance Goals**: Per constitution §runtime budget — a 1,000-cell table
+processes within 100 ms. Per-table resolution is O(entries × tables) selector
+matching done once at `init()` and cached per table in a `WeakMap`; the injection
+pass reads the cached set (O(1) per header). Start-state activation runs the same
+one-time work a manual GS click does. No added per-frame cost.
+
+**Constraints**:
+
+- **Read-only / byte-identical teardown** (constitution §IV): the per-table path
+  only changes *which* enrichments are offered and *whether the toggle starts
+  active* — it adds no new injected nodes beyond what an enrichment already adds,
+  all marked `data-gs-injected` and removed on teardown. A start-active table
+  torn down (global off, or toggle clicked off) MUST restore byte-identical
+  original markup (FR-024).
+- **No regression for non-adopters** (FR-018, SC-009): a table matched by no
+  per-table entry resolves to the identical global set it does today; the table
+  argument is optional and defaults to current behaviour.
+- **`data-gs-ignore` still absolute** (FR-019): opted-out tables are skipped
+  before any per-table matching.
+- **No network, offline-first** (constitution §VI): the welcome page and every
+  inline demo run from `file://` with the IIFE bundle; no fetched fonts/icons.
+- **Bundle budget** (constitution §I; see Constitution Check): the enforced
+  ceiling in `scripts/bundle-size.js` is **42 KB gz** (history in
+  `specs/012-capability-filtering/baseline-bundle-size.md`). This feature budgets
+  a small delta (selector matching + threading a param + extracted toggle
+  functions) **≤ 1.5 KB gz** and MUST stay under 42 KB; the welcome page HTML
+  itself is not bundled. Measured with `node scripts/bundle-size.js --soft`.
+
+**Scale/Scope**: Up to ~10 tables/page (the welcome page has several inline
+demos), each up to ~1,000 rows × ~50 columns, with any combination of existing
+enrichments active and any number of per-table entries. Resolution and injection
+must stay correct and within budget at that composition.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Evaluated against `.specify/memory/constitution.md` v1.1.0:
+
+| Principle | Verdict | Notes |
+|-----------|---------|-------|
+| I. Lightweight & Minimal Dependencies | ⚠ Pass with note | **No new runtime dep.** Bundle: the constitution's 10 KB text is historically superseded by the **enforced 42 KB gz** ceiling in `scripts/bundle-size.js` (recorded in `specs/012-capability-filtering/baseline-bundle-size.md` and spec 014's plan). This feature budgets **≤ 1.5 KB gz** and MUST stay under 42 KB. If it would breach, raise the ceiling explicitly per the constitution and call it out in the PR. Measured with `--soft`. |
+| II. Test Discipline | ✅ Pass | Unit (resolver/selector/parse/default) + jsdom (table-aware injection, programmatic activation, teardown identity) + Storybook + Playwright (welcome-page golden path incl. simultaneous distinct enrichment sets and the start-state contrast). Full suites green before merge (SC-009). |
+| III. Accessibility by Default | ✅ Pass | The GS toggle remains a keyboard-operable `<button>` with correct `aria-expanded`; programmatic start-active sets `aria-expanded="true"` to match. Welcome-page sections use semantic headings/landmarks; the alternating layout uses CSS order only (DOM order stays logical for SR/keyboard); no colour-only signals. No ARIA regressions on teardown. |
+| IV. Progressive Enhancement | ✅ Pass | Pure enhancement: unmatched tables behave exactly as today; an empty per-table enrichment list yields a valid no-enrichment table; malformed `pageConfig.tables` is warned-and-ignored (degrades, never throws into the host page). Welcome page works as a plain `<script>` include. |
+| V. Cross-Browser Compatibility | ✅ Pass | `Element.matches`, `querySelectorAll`, `WeakMap`, CSS grid + `@media` — all > 2 years on every engine. No guarded API. |
+| VI. Offline-First / Air-Gapped | ✅ Pass | Zero network. Welcome page + IIFE + inline demos load from `file://`; no fetched fonts/icons/telemetry. |
+| Development-Phase Posture | N/A (favourable) | Pre-production; config shape and module layout free to evolve. `pageConfig` gains a `tables` field but `window.gridSight.init`'s signature is unchanged. |
+
+**One note (Principle I), no violation.** The 10 KB figure is superseded by the
+recorded 42 KB enforced ceiling; this plan budgets well under it and does not
+change the ceiling. Complexity Tracking left empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/015-welcome-per-table-options/
+├── plan.md                       # This file
+├── spec.md                       # Feature specification (input)
+├── research.md                   # Phase 0 — design decisions
+├── data-model.md                 # Phase 1 — entities + invariants
+├── quickstart.md                 # Phase 1 — wire per-table options in <10 min
+├── contracts/
+│   ├── per-table-options.md      # Phase 1 — config schema + resolution contract
+│   └── welcome-page.md           # Phase 1 — welcome-page structure/content contract
+└── checklists/
+    └── requirements.md           # Spec validation (existing)
+```
+
+### Source Code (repository root)
+
+Reuses the existing single-project layout. The capability lands in `src/core/`
+(resolution) + `src/ui/` (threading the table through injection; extracting the
+toggle activate path); `src/index.ts` threads the table into the auto-render
+gates and triggers start-state. The welcome page is a `public/index.html`
+rewrite.
+
+```text
+src/
+├── core/
+│   ├── page-config.ts                 # MODIFIED — parse + normalise pageConfig.tables (selector, enrichments?, startActive?); validation policy in one place
+│   ├── effective-enabled-set.ts       # MODIFIED — add a per-table tier to resolveEnabledSet (visitor > per-table > page > defaults)
+│   ├── enabled-set-state.ts           # MODIFIED — table-aware getEffectiveEnabledSet(table?)/isEnrichmentEnabled(id, table?); per-table cache (WeakMap); store parsed table entries
+│   └── per-table-options.ts           # NEW — selector→table matching + resolved-config lookup/cache (matchTableEntries, resolveTableConfig)
+├── ui/
+│   ├── header-utils.ts                # MODIFIED — addLozengesToHeader passes its `table` to getEffectiveEnabledSet(table)
+│   ├── toggle-injector.ts             # MODIFIED — extract activateToggle(table)/deactivateToggle(table) from the inline click handler; export for start-state + reuse
+│   └── toggle-panel.ts                # REVIEW — runtime panel reads the page-global set; confirm it composes with per-table (panel edits page tier only)
+├── index.ts                           # MODIFIED — thread the table into isEnrichmentEnabled gates (outlier/freeze/summary) and getEffectiveEnabledSet; after injectToggle, activateToggle when resolved start-state is active
+└── enrichments/                       # REVIEW — slider.ts/slider-threshold.ts/annotations.ts call isEnrichmentEnabled(id) without a table; confirm correct under per-table (pass table where the call is table-scoped)
+
+src/core/__tests__/
+├── per-table-options.test.ts          # NEW — selector matching (id + CSS), last-match-wins, data-gs-ignore precedence, no-match fallback
+├── effective-enabled-set.test.ts      # MODIFIED/EXTENDED — per-table tier precedence + unknown-id drop at the per-table tier
+└── page-config.test.ts                # MODIFIED/EXTENDED — pageConfig.tables parsing/normalisation + malformed-input policy
+
+src/ui/__tests__/
+├── header-utils.per-table.test.ts     # NEW — table-aware lozenge injection (two tables, different sets)
+└── toggle-injector.start-state.test.ts# NEW — programmatic activate/deactivate; aria-expanded; byte-identical teardown
+
+src/stories/
+└── per-table-options.stories.ts       # NEW — two tables, distinct enrichment sets + start-active vs start-inactive
+
+public/
+├── index.html                         # REWRITTEN — hero + principles, 4 alternating feature sections with live demos, explained global toggle, start-state contrast, all-demos index
+└── demo/                              # UNCHANGED — existing demo pages remain; welcome page links to them
+
+e2e/ (Playwright)
+└── welcome-per-table.spec.ts          # NEW — distinct enrichment sets co-resident; start-active vs start-inactive; global toggle round-trip; all demo links reachable; offline/file:// smoke
+```
+
+**Structure Decision**: Reuse the existing single-project layout. Per-table
+resolution is a thin new core module plus a per-table tier added to the existing
+`resolveEnabledSet`, keeping "one place for resolution" intact. The table
+argument is threaded (not duplicated) through the single injection pass. The
+toggle activate/deactivate logic is **extracted, not reimplemented**, so the
+start-state path and a manual click share one code path (DRY; guarantees
+identical teardown). The welcome page is content/HTML/CSS plus a small inline
+config script — no new bundled runtime surface.
+
+## Complexity Tracking
+
+> No violations. Section intentionally empty.

--- a/specs/015-welcome-per-table-options/quickstart.md
+++ b/specs/015-welcome-per-table-options/quickstart.md
@@ -1,0 +1,90 @@
+# Quickstart — Per-Table Options in < 10 minutes
+
+How to give two tables on one page different Grid-Sight features and start
+states. This is the contract the welcome page itself uses.
+
+## 1. Declare per-table options
+
+Before loading the IIFE bundle, set `pageConfig.tables`:
+
+```html
+<script>
+  window.gridSight = {
+    pageConfig: {
+      // Optional page-level default for any UNMATCHED table:
+      enrichments: ['heatmap', 'sort', 'sliders', 'statistics'],
+      // Per-table overrides, addressed by id or CSS selector:
+      tables: [
+        { selector: '#temps',   enrichments: ['heatmap'],          startActive: true  },
+        { selector: '#lookup',  enrichments: ['sliders', 'statistics'], startActive: true },
+        { selector: '#raw',     enrichments: ['sort'] /* startActive omitted → false */ },
+      ],
+    },
+  };
+</script>
+<script src="grid-sight.iife.js"></script>
+```
+
+Result on load:
+- `#temps` shows **only** the heatmap affordance, GS toggle already active.
+- `#lookup` shows **only** sliders + statistics, GS toggle active.
+- `#raw` shows **only** sort, GS toggle **inactive** (visitor clicks GS to reveal).
+- Any other table on the page → the page-level `enrichments`, inactive on load
+  (today's behaviour).
+
+## 2. Address by id or by CSS selector
+
+`selector` is any CSS selector — an id is just `#id`:
+
+```js
+{ selector: '#sales-2026',        enrichments: ['summary-row'] }   // by id
+{ selector: 'table.measurements', enrichments: ['outlier'] }       // by class — all matches
+{ selector: 'section.demo > table', enrichments: ['find-in-table'] } // structural
+```
+
+## 3. Precedence (what wins)
+
+```
+visitor override (URL / localStorage)  >  per-table  >  page-level  >  library defaults
+```
+
+- A visitor enrichment override still wins over per-table (unchanged contract).
+- Unknown ids are silently dropped at every tier.
+- A table matched by **no** entry behaves exactly as before this feature.
+
+## 4. Start-state (the GS toggle’s initial position)
+
+`startActive` only sets whether the **GS toggle** starts revealed — it does NOT
+control whether Grid-Sight attaches to the table (the GS button is present
+either way):
+
+| `startActive` | On load |
+|---------------|---------|
+| `true` | enrichments revealed (as if GS was clicked) |
+| `false` / omitted | GS button shown, enrichments hidden until clicked (**default**) |
+
+Flipping the GS toggle (or the page-wide enable control off→on) returns the table
+to byte-identical original markup when it goes inactive.
+
+## 5. Opt a table out entirely
+
+`data-gs-ignore` still wins over any selector — the table stays fully raw:
+
+```html
+<table id="reference" data-gs-ignore> … </table>
+```
+
+## 6. Verify
+
+```bash
+yarn test          # unit + storybook (resolver precedence, selector match, start-state)
+yarn test:e2e      # welcome-per-table.spec.ts (two distinct sets co-resident; start-state contrast)
+yarn build         # tsc + bundle; node scripts/bundle-size.js --soft  (stay < 42 KB gz)
+```
+
+Sanity checklist:
+- [ ] Two tables show different lozenges at once.
+- [ ] One table starts active, one starts inactive.
+- [ ] An unmatched table looks exactly as it did before.
+- [ ] Turning the global toggle off restores every table to raw markup.
+- [ ] Page + demos work from a `file://` load (no network).

--- a/specs/015-welcome-per-table-options/research.md
+++ b/specs/015-welcome-per-table-options/research.md
@@ -1,0 +1,237 @@
+# Phase 0 — Research & Design Decisions
+
+Feature: Welcome Page Redesign & Per-Table Options
+Date: 2026-05-30
+
+This resolves the open decisions from the spec's Assumptions and the technical
+unknowns from `plan.md`. Each entry: **Decision / Rationale / Alternatives**.
+
+---
+
+## R-1: Where per-table options are declared
+
+**Decision**: Extend the existing config object with a `tables` array:
+`window.gridSight.pageConfig.tables = [{ selector, enrichments?, startActive? }]`
+(and symmetrically on `gridSight.init({ tables: [...] })`). Parsed and normalised
+by `parsePageConfig` alongside the existing `enrichments` / `showToggleUi`.
+
+**Rationale**: Keeps one config entry point and one validation policy
+(`core/page-config.ts`). No change to the frozen `window.gridSight.init`
+*signature* — `tables` rides on the same `pageConfig`/options object the page
+already supplies. Matches how spec 012 added page-level config.
+
+**Alternatives considered**:
+- Per-table HTML attributes (e.g. `data-gs-enrichments="heatmap sort"`). Rejected
+  as the *primary* mechanism: the user explicitly asked for **id or CSS
+  selector** addressing from one declaration; attributes can't express
+  selector-based grouping and scatter config across the markup. (An attribute
+  form could be added later; not in scope.)
+- A separate `window.gridSight.tableConfig` map. Rejected: a second config
+  surface and a second validation path; `pageConfig.tables` reuses the existing
+  one.
+
+---
+
+## R-2: Matcher form — `id` or CSS selector
+
+**Decision**: `selector` is a CSS selector string, matched with
+`document.querySelectorAll(selector)` at `init()`, filtered to `<table>`
+elements. An `#id` is therefore just the common case of a selector. Matching is
+evaluated against the live document once per `init()`.
+
+**Rationale**: One mechanism covers both the "by id" and "by CSS selector" asks
+(an id is `#foo`). Native `querySelectorAll` is > 2 years everywhere, needs no
+dependency, and is the least surprising contract for authors.
+
+**Alternatives considered**: A union type (`{ id }` | `{ selector }`). Rejected
+as redundant — `selector: '#foo'` already expresses id matching with one field.
+
+---
+
+## R-3: Resolution precedence and the per-table tier
+
+**Decision**: Resolution order is **visitor override > per-table > page-level >
+library defaults** (FR-016). Implement by adding a `perTableEnrichments?:
+Set<string>` tier to `resolveEnabledSet`: if a visitor override exists it still
+wins (unchanged); else if the table has a per-table enrichment set, intersect
+*that* with known ids; else fall back to the existing page/defaults branches.
+Unknown ids are dropped at every tier (FR-017), reusing the existing `intersect`
+against `knownIds`.
+
+**Rationale**: Extends the single existing resolver rather than forking it; the
+"unknown ids dropped at every tier" invariant is preserved by construction.
+Visitor-still-wins keeps the spec-012 visitor-override contract intact.
+
+**Alternatives considered**: Merging per-table *into* page-level (union).
+Rejected — the spec wants per-table to **replace** the offered set for that
+table (so a demo can show *only* its feature), not add to the page set.
+
+---
+
+## R-4: Making the gate table-aware
+
+**Decision**: Give `getEffectiveEnabledSet(table?)` and
+`isEnrichmentEnabled(id, table?)` an **optional** table argument
+(`enabled-set-state.ts`). When a table is passed *and* it matches a per-table
+entry, return that table's resolved set (computed once, cached in a `WeakMap<
+HTMLTableElement, Set<string>>`); otherwise return the page-global set exactly as
+today. `header-utils.addLozengesToHeader` already has `table` in scope and passes
+it; the auto-render gates in `index.ts` (`outlier`, `freeze-panes`,
+`summary-row`) pass their `table`.
+
+**Rationale**: Backward compatible by construction — every existing call without
+a table, and every table with no per-table entry, yields the current behaviour
+(SC-009, FR-018). The `WeakMap` cache makes per-header reads O(1) and avoids
+re-matching selectors during re-injection (toggle round-trips).
+
+**Alternatives considered**:
+- A second parallel "per-table" function set. Rejected: two code paths to keep in
+  sync; the optional-arg overload keeps one.
+- Recomputing the resolved set on every header. Rejected: O(headers × entries)
+  selector work; the cache makes it O(entries × tables) once at `init()`.
+
+---
+
+## R-5: Start-state = the GS toggle's initial position (not GS attachment)
+
+**Decision**: `startActive` controls whether a table's "GS" corner toggle begins
+in its **active** state (enrichments revealed) vs **inactive** (default). It does
+**not** attach/detach Grid-Sight — the GS button is injected either way, exactly
+as today. Default is `false` (inactive). Implement by **extracting** the
+activate/deactivate body from the inline click handler in `toggle-injector.ts`
+into `activateToggle(table)` / `deactivateToggle(table)`, having the click
+handler call them, and calling `activateToggle(table)` once after
+`injectToggle(table)` in `index.ts` when the table's resolved start-state is
+active.
+
+**Rationale**: This is precisely the user's clarification ("the GS toggle button
+itself — whether the enrichments are shown for that table"). Extracting (not
+duplicating) the activate path guarantees the programmatic start and a manual
+click run **identical** code, so teardown stays byte-identical (FR-024) and there
+is no second behaviour to test against.
+
+**Alternatives considered**:
+- Simulating a `click()` on the toggle. Rejected: relies on event plumbing and
+  `stopPropagation`, harder to assert in jsdom, and couples start-state to event
+  dispatch. A named function is explicit and unit-testable.
+- A CSS-only "pre-expanded" class. Rejected: the active state also *injects*
+  plus-icons/lozenges and wires the `gridsight:enrichmentSelected` listener —
+  not a pure style toggle.
+
+---
+
+## R-6: Interaction between the global control and per-table start-state
+*(resolves spec Assumption "Global control and start-state interaction")*
+
+**Decision**: The global enable/disable control governs whether Grid-Sight is
+**attached** at all. On (re-)enable, each table is re-processed and its GS toggle
+is set to its **configured start-state** (active/inactive). After that, the
+visitor's own clicks on a table's GS toggle govern its state until the next
+global disable→enable cycle. Global disable removes all GS UI and restores
+byte-identical markup (FR-010, FR-024).
+
+**Rationale**: Deterministic and matches the demonstrated narrative: re-enabling
+returns the page to its authored initial presentation rather than trying to
+remember each table's last manual state (which would need new persistence —
+out of scope, see Storage = none). Simple mental model for the visitor.
+
+**Alternatives considered**: Persisting each table's last toggle state across a
+global off→on. Rejected: introduces new persisted state for no requirement and
+muddies the "re-enable returns to authored start" demo.
+
+---
+
+## R-7: Multiple per-table entries matching the same table
+*(resolves spec Assumption "Deterministic multi-match resolution")*
+
+**Decision**: **Last-match-wins per field.** Entries are applied in declaration
+order; for a table matched by several entries, a later entry's `enrichments`
+and/or `startActive` overrides an earlier one's for that field (a field absent in
+the later entry leaves the earlier value standing). Documented in the contract.
+
+**Rationale**: Mirrors familiar cascade semantics (later rules win), is trivial
+to implement deterministically, and lets an author write a broad selector then a
+narrow override. Per-field (not whole-entry) override avoids an unspecified
+partial entry wiping a previously-set field.
+
+**Alternatives considered**: First-match-wins; most-specific-selector-wins.
+Rejected: first-match prevents targeted overrides; specificity scoring is complex
+and surprising for a config array.
+
+---
+
+## R-8: `data-gs-ignore` vs a matching per-table selector
+*(confirms spec Assumption "Explicit opt-out wins")*
+
+**Decision**: `data-gs-ignore` is checked **before** per-table matching in the
+`init()` table loop (it already is). An ignored table is skipped entirely; a
+per-table selector that also matches it has no effect.
+
+**Rationale**: Keeps the absolute opt-out absolute (FR-019); no new branch — the
+existing early `return` in the `init()` loop already wins.
+
+---
+
+## R-9: Malformed `pageConfig.tables` policy
+
+**Decision**: Extend the existing parse policy: non-array `tables` → warn + ignore
+the field; entries that are non-objects or lack a string `selector` → drop with
+one warning; `enrichments` normalised exactly like the page-level list
+(trim/lowercase/dedup, drop non-strings); `startActive` coerced via `Boolean()`
+with a warn if non-boolean. Each distinct warning at most once per call. Never
+throw into the host page (constitution §IV).
+
+**Rationale**: Consistent with the spec-012 validation policy already in
+`parsePageConfig`; progressive-enhancement safe.
+
+**Alternatives considered**: Throwing on malformed config. Rejected — violates
+"degrade gracefully, never throw into the host page".
+
+---
+
+## R-10: Welcome-page layout technique
+
+**Decision**: Plain semantic HTML + CSS grid. Each feature section is a two-column
+grid (`grid-template-columns: 1fr 1fr`) with the narrative and table in **DOM
+order narrative-then-table**, and alternation achieved with CSS only (`order` /
+`:nth-of-type(even)` reversing the columns) so reading/tab order stays logical.
+A `@media (max-width: …)` collapses to one column. No scrollytelling JS (the user
+chose "alternating two-column rows", not the sticky option).
+
+**Rationale**: Keeps DOM order accessible regardless of visual side (constitution
+§III), needs no JS for layout, and works offline. CSS grid is > 2 years
+everywhere.
+
+**Alternatives considered**: Float/flex hacks (more fragile); sticky
+scrollytelling (explicitly not chosen; more JS).
+
+---
+
+## R-11: Driving the inline demos with the per-table API
+
+**Decision**: The welcome page sets `window.gridSight.pageConfig.tables` so each
+inline demo table (addressed by `id`) offers exactly its section's enrichment(s)
+and starts active; one table is deliberately left `startActive: false` (or
+unspecified) to demonstrate the default. A reference "before" table keeps
+`data-gs-ignore`. The page still registers the slider formula on its slider demo
+(as today) once the IIFE loads.
+
+**Rationale**: Makes the welcome page the first real consumer of the capability —
+dogfooding the contract — and gives the start-state demo (Story 3) for free.
+
+**Alternatives considered**: Hand-wiring each table with bespoke script.
+Rejected: the whole point is to exercise the declarative per-table API.
+
+---
+
+## R-12: Scope guard — no new enrichments, no API-signature change
+
+**Decision**: This feature adds a *new way to scope existing enrichments per
+table* plus a page rewrite. It introduces no new enrichment id and does not
+change the `window.gridSight.init` signature (`tables` rides on the existing
+config object). Existing enrichment modules are reviewed only to confirm their
+`isEnrichmentEnabled` calls remain correct (page-global where they are
+page-global; table-scoped where a table is in hand).
+
+**Rationale**: Bounds the change, protects the frozen public surface, and keeps
+the bundle delta small (≤ 1.5 KB gz target).

--- a/specs/015-welcome-per-table-options/spec.md
+++ b/specs/015-welcome-per-table-options/spec.md
@@ -1,0 +1,399 @@
+# Feature Specification: Welcome Page Redesign & Per-Table Options
+
+**Feature Branch**: `claude/welcome-page-redesign-rVjHn`
+**Created**: 2026-05-30
+**Status**: Draft
+**Input**: User description: "Redesign the Grid-Sight welcome page into a broad, warm-but-technical introduction for general first-time visitors, with alternating narrative + live interactive tables, a hero/principles intro, a retained-and-explained global on/off toggle, a live demonstration of a new start-state option (default off), and links to all existing demos — backed by a new per-table options capability that scopes enrichments (and start-state) to tables addressed by id or CSS selector."
+
+## Overview
+
+Grid-Sight's landing page (`public/index.html`) is today a **demo index for the
+"Dynamic Sliders" feature**: it opens with a dense technical lede, a single
+global on/off toggle, a grid of 12 demo-page links, and three sample tables. It
+assumes the visitor already knows what Grid-Sight is.
+
+This feature reframes that page as a **broad welcome** that orients a
+general, first-time visitor — explaining *what Grid-Sight is and why it
+matters* — and lets them **experiment with the real features inline** as they
+scroll, with narrative on one side and a live interactive table on the other.
+
+Delivering that experience requires a **platform capability** Grid-Sight does
+not have today: the ability to configure **different tables on the same page
+differently**. At present, configuration is strictly page-wide (one enrichment
+list applies to every table; the only per-table control is `data-gs-ignore`,
+which opts a table out entirely). This feature adds **per-table options**
+addressed by **id or CSS selector**, including a **per-table start-state**
+(begin enabled or disabled, default off) so each inline demo can showcase a
+distinct, self-contained slice of functionality.
+
+The two parts are intentionally bundled: the page is the motivating consumer of
+the capability, and the capability is reusable by any host page beyond this one.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - First-time visitor understands what Grid-Sight is (Priority: P1)
+
+A person who has never heard of Grid-Sight arrives at the welcome page. Within
+the first screen they read a plain-language explanation of what it is (it
+enriches ordinary HTML tables in place), the problem it solves (no rebuild, no
+backend, works on the tables you already have), and the principles that make it
+trustworthy (works offline / air-gapped, no runtime dependencies, enhances
+progressively, accessible, and leaves the original table byte-identical when
+turned off). They leave able to describe Grid-Sight in a sentence.
+
+**Why this priority**: This is the core goal of the redesign — the page exists
+to make a cold visitor *get it*. Without this, the inline demos have no framing.
+It delivers value even if no other story ships (the intro alone is a better
+welcome than today's page).
+
+**Independent Test**: Load the welcome page with Grid-Sight disabled; confirm
+the hero and principles section communicates purpose and principles in
+plain language without requiring the reader to interact with any table.
+
+**Acceptance Scenarios**:
+
+1. **Given** a visitor who has never used Grid-Sight, **When** they load the
+   welcome page, **Then** the first section states what Grid-Sight is, the
+   problem it solves, and its guiding principles in plain language before any
+   feature demo.
+2. **Given** the welcome page, **When** the visitor reads the intro, **Then**
+   the principles (offline/air-gapped, zero runtime dependencies, progressive
+   enhancement, accessibility, read-only/byte-identical teardown) are each
+   stated in terms a non-specialist can understand.
+3. **Given** the welcome page loaded from a `file://` URL with no network,
+   **When** it renders, **Then** the intro and all assets display fully (no
+   broken or network-dependent content).
+
+---
+
+### User Story 2 - Visitor experiments with features inline while scrolling (Priority: P1)
+
+As the visitor scrolls past the intro, they encounter a sequence of feature
+sections, one per feature area. Each section presents narrative on one side and
+a **live, interactive sample table** on the other, with the side that holds the
+narrative **alternating** down the page. The visitor can directly operate the
+feature in each table (move a slider, click a heatmap lozenge, sort/filter,
+search, add a virtual column, annotate a cell, etc.) without leaving the page.
+On a narrow screen the two columns stack vertically. Each section links out to
+the related full demo pages for deeper exploration.
+
+**Why this priority**: This is the second half of the core experience — letting
+visitors *feel* the value, not just read about it. It depends on the per-table
+options capability (Story 4) to show distinct features side-by-side.
+
+**Independent Test**: Scroll through the page and operate each section's table;
+confirm the feature works live inline and the layout alternates on wide screens
+and stacks on narrow screens.
+
+**Acceptance Scenarios**:
+
+1. **Given** the welcome page on a wide screen, **When** the visitor scrolls
+   through the feature sections, **Then** each section shows narrative beside a
+   live interactive table, and the narrative/table sides alternate between
+   consecutive sections.
+2. **Given** the welcome page on a narrow (mobile-width) screen, **When** a
+   feature section renders, **Then** the narrative and table stack into a single
+   readable column.
+3. **Given** any feature section's inline table, **When** the visitor operates
+   that feature (per the feature's normal interaction), **Then** the feature
+   responds live in place, exactly as it would on its dedicated demo page.
+4. **Given** a feature section, **When** the visitor wants to explore more,
+   **Then** the section provides links to the related existing demo page(s) for
+   that feature area.
+5. **Given** the welcome page, **When** the visitor reaches the four areas,
+   **Then** all four are represented: (a) sliders & interpolation, (b) visual
+   analysis (heatmap, outlier marker, statistics popup, summary row), (c)
+   navigation & search (sort, filter, find-in-table, freeze panes), and (d)
+   derived data & notes (virtual columns Σ/⌇/Δ, cell annotations).
+
+---
+
+### User Story 3 - Visitor sees the on/off and start-state behaviour explained and demonstrated (Priority: P2)
+
+The page keeps a global "Grid-Sight enabled" control and the raw-vs-enriched
+contrast, but instead of a bare checkbox it is **woven into the narrative** so
+the visitor understands *why* it exists: Grid-Sight is a non-destructive overlay
+that can be turned off to reveal the untouched table. Separately, the page
+**demonstrates the new start-state option**: at least one inline table is
+configured to begin in the raw, un-enriched state (default off) and the visitor
+can enable it on demand, seeing the before/after transition for themselves.
+
+**Why this priority**: Reinforces the "progressive, non-destructive" principle
+viscerally and exercises the new start-state capability in front of the visitor.
+Valuable but secondary to having the intro and inline demos at all.
+
+**Independent Test**: Toggle the global control and observe the whole page move
+between raw and enriched; separately, find the start-disabled table, confirm it
+begins raw, enable it, and confirm it enriches without a page reload.
+
+**Acceptance Scenarios**:
+
+1. **Given** the welcome page, **When** the visitor reads the section
+   containing the global enable/disable control, **Then** the narrative explains
+   that Grid-Sight is a non-destructive overlay and that turning it off restores
+   the original table.
+2. **Given** the global control is enabled, **When** the visitor turns it off,
+   **Then** every Grid-Sight-managed table on the page returns to its raw
+   appearance; turning it back on restores the enrichments.
+3. **Given** a table configured to start disabled (default off), **When** the
+   page first loads, **Then** that table is shown raw (no lozenges/enrichment)
+   while other tables configured to start enabled are already enriched.
+4. **Given** a start-disabled table, **When** the visitor enables it (via the
+   provided control/affordance), **Then** it becomes enriched in place without a
+   full page reload.
+
+---
+
+### User Story 4 - Host author configures different tables differently on one page (Priority: P1)
+
+An author embedding Grid-Sight (the welcome page is the first such author, but
+this applies to any host) needs different tables on the same page to expose
+different feature sets — and some to start enabled while others start disabled.
+The author declares per-table options by **id or CSS selector**, listing the
+enrichments each matched table should offer and whether it starts enabled. A
+table not matched by any per-table entry continues to behave exactly as it does
+today under the page-level configuration.
+
+**Why this priority**: This is the enabling capability for Story 2's
+side-by-side inline demos. It is foundational: without it, every table on a page
+shows the same features and the same start-state. It is independently testable
+and independently valuable to any Grid-Sight consumer.
+
+**Independent Test**: On a test page, declare per-table options for two tables
+by id and by CSS selector with different enrichment lists and start-states;
+confirm each matched table offers only its declared enrichments and honours its
+declared start-state, while an unmatched table follows the page-level config.
+
+**Acceptance Scenarios**:
+
+1. **Given** a page declaring per-table options that match a table by its `id`,
+   **When** Grid-Sight initialises, **Then** that table offers exactly the
+   enrichments declared for it (intersected with the enrichments Grid-Sight
+   knows about), independent of other tables.
+2. **Given** a page declaring per-table options that match tables by a CSS
+   selector, **When** Grid-Sight initialises, **Then** every table matching the
+   selector receives those options.
+3. **Given** a table matched by a per-table entry **and** a page-level
+   configuration **and** a visitor override, **When** the enabled set is
+   resolved, **Then** precedence is: visitor override > per-table > page-level >
+   library defaults.
+4. **Given** a per-table entry referencing an unknown enrichment id, **When**
+   options are resolved, **Then** the unknown id is dropped (consistent with
+   existing resolution behaviour) and no error is surfaced to the host page.
+5. **Given** a table not matched by any per-table entry, **When** Grid-Sight
+   initialises, **Then** it behaves exactly as under the current page-level
+   configuration (no regression).
+6. **Given** a per-table entry that sets start-state, **When** the page loads,
+   **Then** the matched table begins enabled or disabled as declared, defaulting
+   to disabled when the per-table entry specifies start-state without an
+   explicit value.
+7. **Given** two per-table entries whose selectors both match the same table,
+   **When** options are resolved, **Then** resolution is deterministic and
+   documented (see Assumptions), with no ambiguity in the resulting option set.
+
+---
+
+### User Story 5 - Visitor can still reach every existing demo (Priority: P3)
+
+A visitor who wants the full catalogue can still find links to all existing demo
+pages from the welcome page — both contextually (within each feature section)
+and collectively (a consolidated "more demos" index, e.g. near the bottom).
+
+**Why this priority**: Preserves existing navigation value so nothing currently
+reachable from the landing page is lost. Lowest priority because it is
+preservation rather than new value.
+
+**Independent Test**: From the welcome page, confirm every existing demo page is
+reachable via a working link.
+
+**Acceptance Scenarios**:
+
+1. **Given** the redesigned welcome page, **When** the visitor looks for more
+   examples, **Then** all existing demo pages remain reachable via working links
+   (no demo page becomes orphaned).
+2. **Given** a feature section, **When** the visitor wants more of that feature
+   type, **Then** that section links to the corresponding demo page(s).
+
+---
+
+### Edge Cases
+
+- **No matching tables for a selector**: a per-table entry whose selector
+  matches nothing is a no-op (no error, no effect on other tables).
+- **Selector matches an opted-out table**: a table marked `data-gs-ignore`
+  remains fully opted out even if a per-table selector also matches it
+  (explicit opt-out wins; see Assumptions).
+- **Empty enrichment list for a table**: a matched table declared with an empty
+  enrichment list offers no enrichments (a valid, distinct state from "not
+  matched").
+- **Start-disabled then global-disable then global-enable**: a table that began
+  disabled and was individually enabled should follow the page-wide enable/
+  disable thereafter without losing its identity; the resulting state must be
+  unambiguous (see Assumptions).
+- **Global toggle while a start-disabled table is still raw**: turning the
+  global control on must not force-enable tables that are configured to start
+  (and remain) disabled unless the visitor enabled them — the interaction
+  between the global control and per-table start-state must be unambiguous (see
+  Assumptions).
+- **Offline / `file://` load**: the entire page, including every inline demo,
+  must function with no network access.
+- **Teardown identity**: turning any enrichment or the whole page off must
+  restore the affected tables to byte-identical original markup.
+- **Selector specificity collisions**: overlapping selectors matching the same
+  table must resolve deterministically (see Assumptions).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Welcome page experience
+
+- **FR-001**: The welcome page MUST open with an introductory section that
+  states, in plain language for a non-specialist, what Grid-Sight is and the
+  problem it solves (enriching existing HTML tables in place without a rebuild).
+- **FR-002**: The introductory section MUST communicate Grid-Sight's guiding
+  principles: works offline / air-gapped, no runtime dependencies, progressive
+  enhancement, accessibility by default, and read-only / byte-identical
+  teardown.
+- **FR-003**: The page MUST present feature sections covering all four areas:
+  (a) sliders & interpolation, (b) visual analysis (heatmap, outlier marker,
+  statistics popup, summary row), (c) navigation & search (sort, filter,
+  find-in-table, freeze panes), and (d) derived data & notes (virtual columns
+  cumulative/sparkline/compare, cell annotations).
+- **FR-004**: Each feature section MUST place explanatory narrative alongside a
+  live, interactive sample table, and the side holding the narrative MUST
+  alternate between consecutive sections on wide screens.
+- **FR-005**: On narrow (mobile-width) screens, each feature section's narrative
+  and table MUST stack into a single readable column.
+- **FR-006**: Each inline sample table MUST let the visitor operate the
+  feature(s) that section showcases, behaving as it would on the feature's
+  dedicated demo page.
+- **FR-007**: A section MAY contain more than one sample table when that helps
+  illustrate the feature area.
+- **FR-008**: Each feature section MUST link to the related existing demo
+  page(s) for that feature area.
+- **FR-009**: The page MUST retain a global enable/disable control for
+  Grid-Sight and MUST explain within the narrative that Grid-Sight is a
+  non-destructive overlay that can be switched off to reveal the original
+  tables.
+- **FR-010**: Toggling the global control off MUST return all Grid-Sight-managed
+  tables on the page to their raw appearance, and toggling it on MUST restore
+  the enrichments — without a full page reload.
+- **FR-011**: The page MUST demonstrate the new start-state option live: at
+  least one inline table MUST begin in the raw (disabled) state and offer the
+  visitor a way to enable it in place.
+- **FR-012**: All existing demo pages MUST remain reachable from the welcome
+  page via working links, including a consolidated index of all demos.
+- **FR-013**: The welcome page MUST render and function fully when loaded
+  offline, including from a `file://` URL, with no network requests at runtime.
+
+#### Per-table options capability
+
+- **FR-014**: Grid-Sight MUST allow a host page to declare options that apply to
+  specific tables, with each table addressed by its `id` or by a CSS selector.
+- **FR-015**: Per-table options MUST be able to specify the set of enrichments a
+  matched table offers, independently of the page-level enrichment set.
+- **FR-016**: When resolving the enrichments offered by a table, Grid-Sight MUST
+  apply precedence: visitor override > per-table options > page-level
+  configuration > library defaults.
+- **FR-017**: Unknown enrichment ids in per-table options MUST be dropped during
+  resolution (consistent with existing page-level resolution), without throwing
+  into the host page.
+- **FR-018**: A table not matched by any per-table entry MUST behave exactly as
+  it does under the current page-level configuration (no regression).
+- **FR-019**: A table explicitly opted out via `data-gs-ignore` MUST remain
+  opted out regardless of any per-table selector that also matches it.
+- **FR-020**: Per-table options MUST be able to specify whether a matched table
+  starts enabled or disabled, defaulting to **disabled** when start-state is
+  specified without an explicit value.
+- **FR-021**: A table configured to start disabled MUST load in its raw,
+  un-enriched state, and MUST be able to become enriched in place (without a
+  full page reload) when subsequently enabled.
+- **FR-022**: Introducing per-table start-state MUST NOT change Grid-Sight's
+  existing default behaviour for tables/pages that do not use the option
+  (existing consumers' tables continue to enrich on load as they do today).
+- **FR-023**: Resolution MUST be deterministic when multiple per-table entries
+  match the same table; the resolution rule MUST be documented.
+- **FR-024**: Enabling or disabling any table (individually or via the global
+  control) MUST restore byte-identical original markup for the affected table
+  when it returns to the raw state.
+
+### Key Entities
+
+- **Per-table option entry**: An author-declared association between a table
+  matcher (an `id` or CSS selector) and the options that apply to matched
+  tables. Key attributes: the matcher, the enrichment set offered, and the
+  start-state (enabled/disabled, default disabled).
+- **Resolved table configuration**: The effective set of enrichments and the
+  start-state for a single table, after combining visitor override, per-table
+  options, page-level configuration, and library defaults by precedence.
+- **Feature section** (welcome page): A unit of the welcome page pairing
+  narrative with one or more live sample tables for a feature area, plus links
+  to related demo pages.
+- **Global enable/disable state**: The page-wide on/off condition for
+  Grid-Sight, presented with explanatory narrative and reflecting the
+  non-destructive overlay model.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A first-time visitor can state what Grid-Sight is and one reason
+  it matters after reading only the first (intro) section, without interacting
+  with any table.
+- **SC-002**: All four feature areas are represented by at least one live,
+  operable inline table on the welcome page, and a visitor can operate each one
+  without navigating away.
+- **SC-003**: On a wide screen, narrative and table sides alternate across
+  consecutive feature sections; on a narrow screen, every section stacks to a
+  single column with no horizontal overflow.
+- **SC-004**: At least one inline table demonstrably starts in the raw state and
+  becomes enriched in place when the visitor enables it, with no full page
+  reload.
+- **SC-005**: Two or more tables on the same page simultaneously expose
+  different enrichment sets driven solely by per-table options.
+- **SC-006**: Every existing demo page reachable from today's landing page
+  remains reachable from the redesigned page (zero orphaned demos).
+- **SC-007**: The welcome page loads and every inline demo functions with no
+  network access (verified from a `file://` load).
+- **SC-008**: Turning Grid-Sight off (globally or per table) restores affected
+  tables to byte-identical original markup.
+- **SC-009**: Existing pages that do not use per-table options exhibit no change
+  in behaviour (all existing automated suites remain green).
+- **SC-010**: Resolution precedence (visitor > per-table > page > defaults) and
+  start-state default (off) hold for every combination exercised in tests.
+
+## Assumptions
+
+- **Spec directory vs. branch**: Development proceeds on the pre-assigned
+  session branch `claude/welcome-page-redesign-rVjHn` rather than a newly
+  created numbered branch; the spec directory is numbered `015` purely for
+  sequential cataloguing.
+- **Library default unchanged**: The existing global default (Grid-Sight
+  enriches detected tables on load) is preserved for any page/table that does
+  not opt into per-table start-state. "Default off" applies specifically to the
+  new per-table start-state option, not to Grid-Sight as a whole.
+- **Explicit opt-out wins**: `data-gs-ignore` continues to be an absolute
+  opt-out and takes precedence over any per-table selector match.
+- **Deterministic multi-match resolution**: When multiple per-table entries
+  match one table, later entries override earlier ones on a per-field basis
+  (last-match-wins), mirroring familiar cascade semantics; this will be stated
+  in the capability's documentation.
+- **Global control and start-state interaction**: The page-wide enable control
+  reflects and drives the overall enabled state; a table configured to start
+  disabled stays raw until individually enabled or until the visitor uses the
+  global control to enable the page. The precise interaction will be pinned down
+  during planning, but the visible behaviour must remain unambiguous and match
+  the demonstrated narrative.
+- **Selector matching scope**: CSS selectors are matched against table elements
+  in the host document at initialisation; selectors that match non-table
+  elements are ignored for table-option purposes.
+- **Curated inline demos**: The welcome page reuses the existing sample data and
+  feature behaviours; this feature does not introduce new enrichment types, only
+  a new way to scope existing ones per table plus the page redesign.
+- **Tone and audience**: Content targets general/mixed first-time visitors in a
+  technical-but-warm voice; exact copy is a content task within this feature, not
+  a separate one.
+- **No new runtime dependencies**: The redesign and capability use only existing
+  Grid-Sight primitives and ship within the enforced bundle ceiling; the page
+  works with the standalone IIFE bundle offline.

--- a/specs/015-welcome-per-table-options/spec.md
+++ b/specs/015-welcome-per-table-options/spec.md
@@ -22,9 +22,25 @@ not have today: the ability to configure **different tables on the same page
 differently**. At present, configuration is strictly page-wide (one enrichment
 list applies to every table; the only per-table control is `data-gs-ignore`,
 which opts a table out entirely). This feature adds **per-table options**
-addressed by **id or CSS selector**, including a **per-table start-state**
-(begin enabled or disabled, default off) so each inline demo can showcase a
-distinct, self-contained slice of functionality.
+addressed by **id or CSS selector**, including a **per-table start-state** so
+each inline demo can showcase a distinct, self-contained slice of functionality.
+
+**Terminology — two distinct layers.** A reader can confuse "Grid-Sight on/off"
+with "enrichments shown". They are different:
+
+- **Grid-Sight attached to a table** — Grid-Sight has detected and is managing
+  the table, shown by the small **"GS" corner toggle button**. Whether
+  Grid-Sight is attached at all is governed by the existing global enable/
+  disable control, table detection, and `data-gs-ignore`. This feature does
+  **not** change that.
+- **Enrichments revealed (the GS toggle's active state)** — the per-table "GS"
+  button has two states. Today it starts **inactive**, so a managed table shows
+  the GS button but no lozenges/enrichment affordances until the visitor clicks
+  GS; clicking flips it **active** and the lozenges appear. The new **per-table
+  start-state** option controls *which of these two states the GS button begins
+  in for a given table* — **default off (inactive)**, exactly as today. Setting
+  it on means that table loads with its enrichments already revealed, as if the
+  GS button had been clicked. It does not attach or detach Grid-Sight.
 
 The two parts are intentionally bundled: the page is the motivating consumer of
 the capability, and the capability is reusable by any host page beyond this one.
@@ -75,7 +91,10 @@ narrative **alternating** down the page. The visitor can directly operate the
 feature in each table (move a slider, click a heatmap lozenge, sort/filter,
 search, add a virtual column, annotate a cell, etc.) without leaving the page.
 On a narrow screen the two columns stack vertically. Each section links out to
-the related full demo pages for deeper exploration.
+the related full demo pages for deeper exploration. So that the feature is
+visible without the visitor having to discover the "GS" button, most inline
+demo tables load with their GS toggle already active (enrichments revealed) —
+which is exactly what the per-table start-state option (Story 4) enables.
 
 **Why this priority**: This is the second half of the core experience — letting
 visitors *feel* the value, not just read about it. It depends on the per-table
@@ -114,17 +133,21 @@ The page keeps a global "Grid-Sight enabled" control and the raw-vs-enriched
 contrast, but instead of a bare checkbox it is **woven into the narrative** so
 the visitor understands *why* it exists: Grid-Sight is a non-destructive overlay
 that can be turned off to reveal the untouched table. Separately, the page
-**demonstrates the new start-state option**: at least one inline table is
-configured to begin in the raw, un-enriched state (default off) and the visitor
-can enable it on demand, seeing the before/after transition for themselves.
+**demonstrates the new per-table start-state option**: the page shows both
+states side by side — at least one table whose GS toggle starts **inactive**
+(enrichments hidden until the visitor clicks GS, the default) and at least one
+whose GS toggle starts **active** (enrichments already revealed on load) — so
+the visitor sees the difference and can flip a GS toggle themselves.
 
 **Why this priority**: Reinforces the "progressive, non-destructive" principle
 viscerally and exercises the new start-state capability in front of the visitor.
 Valuable but secondary to having the intro and inline demos at all.
 
 **Independent Test**: Toggle the global control and observe the whole page move
-between raw and enriched; separately, find the start-disabled table, confirm it
-begins raw, enable it, and confirm it enriches without a page reload.
+between attached and fully raw; separately, confirm one table loads with
+enrichments already revealed (GS toggle active) and another loads with
+enrichments hidden (GS toggle inactive), and that clicking a table's GS toggle
+flips its state without a page reload.
 
 **Acceptance Scenarios**:
 
@@ -134,13 +157,16 @@ begins raw, enable it, and confirm it enriches without a page reload.
    the original table.
 2. **Given** the global control is enabled, **When** the visitor turns it off,
    **Then** every Grid-Sight-managed table on the page returns to its raw
-   appearance; turning it back on restores the enrichments.
-3. **Given** a table configured to start disabled (default off), **When** the
-   page first loads, **Then** that table is shown raw (no lozenges/enrichment)
-   while other tables configured to start enabled are already enriched.
-4. **Given** a start-disabled table, **When** the visitor enables it (via the
-   provided control/affordance), **Then** it becomes enriched in place without a
-   full page reload.
+   appearance (GS button and any revealed enrichments removed); turning it back
+   on restores them.
+3. **Given** one table configured with start-state **on** and another with
+   start-state **off (default)**, **When** the page first loads, **Then** the
+   first table already shows its enrichments revealed (GS toggle active) while
+   the second shows only the GS corner button with enrichments hidden.
+4. **Given** a table whose GS toggle starts inactive, **When** the visitor
+   clicks its GS toggle, **Then** that table's enrichments are revealed in place
+   without a full page reload (and clicking again hides them) — i.e. the
+   start-state only sets the initial position of an otherwise normal toggle.
 
 ---
 
@@ -184,9 +210,10 @@ declared start-state, while an unmatched table follows the page-level config.
    initialises, **Then** it behaves exactly as under the current page-level
    configuration (no regression).
 6. **Given** a per-table entry that sets start-state, **When** the page loads,
-   **Then** the matched table begins enabled or disabled as declared, defaulting
-   to disabled when the per-table entry specifies start-state without an
-   explicit value.
+   **Then** the matched table's GS toggle begins active (enrichments revealed)
+   or inactive (enrichments hidden) as declared, defaulting to **inactive** when
+   start-state is not specified — without changing whether Grid-Sight is
+   attached to the table.
 7. **Given** two per-table entries whose selectors both match the same table,
    **When** options are resolved, **Then** resolution is deterministic and
    documented (see Assumptions), with no ambiguity in the resulting option set.
@@ -226,14 +253,13 @@ reachable via a working link.
 - **Empty enrichment list for a table**: a matched table declared with an empty
   enrichment list offers no enrichments (a valid, distinct state from "not
   matched").
-- **Start-disabled then global-disable then global-enable**: a table that began
-  disabled and was individually enabled should follow the page-wide enable/
-  disable thereafter without losing its identity; the resulting state must be
-  unambiguous (see Assumptions).
-- **Global toggle while a start-disabled table is still raw**: turning the
-  global control on must not force-enable tables that are configured to start
-  (and remain) disabled unless the visitor enabled them — the interaction
-  between the global control and per-table start-state must be unambiguous (see
+- **Start-state vs. visitor's own clicks**: start-state only sets the GS
+  toggle's *initial* position; once the visitor clicks a table's GS toggle, that
+  click governs. Re-running enrichment resolution must not silently snap a
+  toggle back to its start-state.
+- **Global disable then re-enable**: when Grid-Sight is globally disabled then
+  re-enabled, each table's GS toggle returns to its configured start-state
+  (active/inactive) on re-attach; the resulting state must be unambiguous (see
   Assumptions).
 - **Offline / `file://` load**: the entire page, including every inline demo,
   must function with no network access.
@@ -277,11 +303,14 @@ reachable via a working link.
   non-destructive overlay that can be switched off to reveal the original
   tables.
 - **FR-010**: Toggling the global control off MUST return all Grid-Sight-managed
-  tables on the page to their raw appearance, and toggling it on MUST restore
-  the enrichments — without a full page reload.
-- **FR-011**: The page MUST demonstrate the new start-state option live: at
-  least one inline table MUST begin in the raw (disabled) state and offer the
-  visitor a way to enable it in place.
+  tables on the page to their raw appearance (GS toggles and any revealed
+  enrichments removed), and toggling it on MUST re-attach Grid-Sight with each
+  table's GS toggle in its configured start-state — without a full page reload.
+- **FR-011**: The page MUST demonstrate the new per-table start-state option
+  live: at least one inline table MUST load with its GS toggle **active**
+  (enrichments revealed on load) and at least one MUST load with its GS toggle
+  **inactive** (enrichments hidden until the visitor clicks GS), with the
+  visitor able to flip either toggle in place.
 - **FR-012**: All existing demo pages MUST remain reachable from the welcome
   page via working links, including a consolidated index of all demos.
 - **FR-013**: The welcome page MUST render and function fully when loaded
@@ -303,30 +332,36 @@ reachable via a working link.
   it does under the current page-level configuration (no regression).
 - **FR-019**: A table explicitly opted out via `data-gs-ignore` MUST remain
   opted out regardless of any per-table selector that also matches it.
-- **FR-020**: Per-table options MUST be able to specify whether a matched table
-  starts enabled or disabled, defaulting to **disabled** when start-state is
-  specified without an explicit value.
-- **FR-021**: A table configured to start disabled MUST load in its raw,
-  un-enriched state, and MUST be able to become enriched in place (without a
-  full page reload) when subsequently enabled.
+- **FR-020**: Per-table options MUST be able to specify whether a matched
+  table's GS toggle starts **active** (enrichments revealed) or **inactive**
+  (enrichments hidden), defaulting to **inactive** when start-state is not
+  specified. This option MUST NOT affect whether Grid-Sight is attached to the
+  table (the GS corner toggle is present in both cases, exactly as today).
+- **FR-021**: A table whose GS toggle starts inactive MUST show the GS corner
+  toggle with no lozenges/enrichments revealed (today's behaviour); a table
+  whose GS toggle starts active MUST load with its enrichments already revealed,
+  and in both cases the visitor MUST be able to flip the toggle in place without
+  a full page reload.
 - **FR-022**: Introducing per-table start-state MUST NOT change Grid-Sight's
-  existing default behaviour for tables/pages that do not use the option
-  (existing consumers' tables continue to enrich on load as they do today).
+  existing default behaviour for tables/pages that do not use the option (the GS
+  toggle continues to start inactive, with enrichments revealed only on click,
+  exactly as today).
 - **FR-023**: Resolution MUST be deterministic when multiple per-table entries
   match the same table; the resolution rule MUST be documented.
-- **FR-024**: Enabling or disabling any table (individually or via the global
-  control) MUST restore byte-identical original markup for the affected table
-  when it returns to the raw state.
+- **FR-024**: Hiding a table's enrichments (toggling its GS button inactive) and
+  disabling Grid-Sight via the global control MUST each restore byte-identical
+  original markup for the affected table when it returns to the raw state.
 
 ### Key Entities
 
 - **Per-table option entry**: An author-declared association between a table
   matcher (an `id` or CSS selector) and the options that apply to matched
-  tables. Key attributes: the matcher, the enrichment set offered, and the
-  start-state (enabled/disabled, default disabled).
-- **Resolved table configuration**: The effective set of enrichments and the
-  start-state for a single table, after combining visitor override, per-table
-  options, page-level configuration, and library defaults by precedence.
+  tables. Key attributes: the matcher, the enrichment set offered, and the GS
+  toggle start-state (active/inactive, default inactive).
+- **Resolved table configuration**: The effective set of enrichments and the GS
+  toggle start-state for a single table, after combining visitor override,
+  per-table options, page-level configuration, and library defaults by
+  precedence.
 - **Feature section** (welcome page): A unit of the welcome page pairing
   narrative with one or more live sample tables for a feature area, plus links
   to related demo pages.
@@ -347,9 +382,10 @@ reachable via a working link.
 - **SC-003**: On a wide screen, narrative and table sides alternate across
   consecutive feature sections; on a narrow screen, every section stacks to a
   single column with no horizontal overflow.
-- **SC-004**: At least one inline table demonstrably starts in the raw state and
-  becomes enriched in place when the visitor enables it, with no full page
-  reload.
+- **SC-004**: On load, at least one inline table shows its enrichments already
+  revealed (GS toggle active) and at least one shows enrichments hidden (GS
+  toggle inactive); clicking a GS toggle flips its state in place with no full
+  page reload.
 - **SC-005**: Two or more tables on the same page simultaneously expose
   different enrichment sets driven solely by per-table options.
 - **SC-006**: Every existing demo page reachable from today's landing page
@@ -361,7 +397,8 @@ reachable via a working link.
 - **SC-009**: Existing pages that do not use per-table options exhibit no change
   in behaviour (all existing automated suites remain green).
 - **SC-010**: Resolution precedence (visitor > per-table > page > defaults) and
-  start-state default (off) hold for every combination exercised in tests.
+  the GS toggle start-state default (inactive/off) hold for every combination
+  exercised in tests.
 
 ## Assumptions
 
@@ -369,10 +406,16 @@ reachable via a working link.
   session branch `claude/welcome-page-redesign-rVjHn` rather than a newly
   created numbered branch; the spec directory is numbered `015` purely for
   sequential cataloguing.
-- **Library default unchanged**: The existing global default (Grid-Sight
-  enriches detected tables on load) is preserved for any page/table that does
-  not opt into per-table start-state. "Default off" applies specifically to the
-  new per-table start-state option, not to Grid-Sight as a whole.
+- **Start-state is the GS toggle's position, not GS attachment**: The per-table
+  start-state controls only whether a managed table's "GS" toggle begins active
+  (enrichments revealed) or inactive (enrichments hidden). It never attaches or
+  detaches Grid-Sight from a table. Whether Grid-Sight is attached at all remains
+  governed by the global enable/disable control, table detection, and
+  `data-gs-ignore`, unchanged by this feature.
+- **Default unchanged**: The existing default (a managed table's GS toggle
+  starts inactive — enrichments revealed only when the visitor clicks GS) is
+  preserved for any table that does not opt into a per-table start-state.
+  "Default off" means the GS toggle defaults to inactive, exactly as today.
 - **Explicit opt-out wins**: `data-gs-ignore` continues to be an absolute
   opt-out and takes precedence over any per-table selector match.
 - **Deterministic multi-match resolution**: When multiple per-table entries
@@ -380,9 +423,10 @@ reachable via a working link.
   (last-match-wins), mirroring familiar cascade semantics; this will be stated
   in the capability's documentation.
 - **Global control and start-state interaction**: The page-wide enable control
-  reflects and drives the overall enabled state; a table configured to start
-  disabled stays raw until individually enabled or until the visitor uses the
-  global control to enable the page. The precise interaction will be pinned down
+  governs whether Grid-Sight is attached to the page's tables at all. When
+  Grid-Sight is (re-)enabled, each table's GS toggle takes its configured
+  start-state (active/inactive); thereafter the visitor's own clicks on a GS
+  toggle govern its state. The precise re-attach behaviour will be pinned down
   during planning, but the visible behaviour must remain unambiguous and match
   the demonstrated narrative.
 - **Selector matching scope**: CSS selectors are matched against table elements

--- a/specs/015-welcome-per-table-options/tasks.md
+++ b/specs/015-welcome-per-table-options/tasks.md
@@ -1,0 +1,266 @@
+# Tasks: Welcome Page Redesign & Per-Table Options
+
+**Input**: Design documents from `/specs/015-welcome-per-table-options/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: INCLUDED — the Grid-Sight constitution (§II Test Discipline) requires
+every feature to land with automated tests, and the spec's Testing strategy calls
+for Vitest unit, jsdom interaction, Storybook, and Playwright e2e coverage.
+
+**Organization**: Tasks are grouped by user story. Stories are sequenced so the
+enabling capability (US4, the per-table options API) lands first because US2/US3
+build on it; US1 and US5 are page-only and independent.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: US1–US5 maps to the spec's user stories
+- All paths are repository-relative (single-project layout per plan.md)
+
+## Path Conventions
+
+- Core logic: `src/core/`; UI/injection: `src/ui/`; entry/wiring: `src/index.ts`
+- Unit/jsdom tests: co-located in `src/**/__tests__/`
+- Storybook: `src/stories/`; Playwright e2e: `e2e/`
+- Welcome page: `public/index.html` (links to existing `public/demo/**`)
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Baseline and scaffolding shared by later phases.
+
+- [ ] T001 Confirm baseline green before changes: run `yarn test` and `yarn build` (record current bundle size from `node scripts/bundle-size.js --soft` as the delta baseline)
+- [ ] T002 [P] Create stub module `src/core/per-table-options.ts` exporting `resolveTableConfig(table)` and `matchTableEntries(table)` signatures + the `ResolvedTableConfig` type (no logic yet), per `contracts/per-table-options.md`
+- [ ] T003 [P] Create empty Playwright spec skeleton `e2e/welcome-per-table.spec.ts` with `test.describe` blocks named for US2/US3/US5 scenarios (skipped placeholders)
+
+**Checkpoint**: Baseline recorded; new module + e2e file exist as stubs.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The config-parsing + resolution shape that both the API story (US4)
+and the start-state demo (US3) consume. Kept minimal; the table-aware *wiring*
+lives in US4.
+
+**⚠️ CRITICAL**: US4 cannot begin until this phase is complete.
+
+- [ ] T004 Extend `ParsedPageConfig` in `src/core/page-config.ts` with `tables: ParsedTableOptionEntry[]` and define the `ParsedTableOptionEntry` type (`selector: string`, `enrichments: Set<string> | undefined`, `startActive: boolean`) per `data-model.md`
+- [ ] T005 Implement `pageConfig.tables` parsing + normalisation in `parsePageConfig` (`src/core/page-config.ts`): array guard, per-entry `selector` validation, `enrichments` trim/lowercase/dedup + non-string drop, `startActive` boolean coercion — each distinct warning once, never throw (R-9 / data-model validation rules)
+
+**Checkpoint**: Config parsing accepts and normalises `tables`; resolver shape ready.
+
+---
+
+## Phase 3: User Story 4 - Per-table options API (Priority: P1) 🎯 MVP (enabling capability)
+
+**Goal**: Different tables on one page offer different enrichment sets and
+start-states, addressed by id/CSS selector, with precedence
+visitor > per-table > page > defaults.
+
+**Independent Test**: On a test page declare per-table options for two tables (by
+id and by CSS selector) with different enrichment lists and start-states; confirm
+each matched table offers only its declared enrichments and honours its
+start-state, while an unmatched table follows the page-level config.
+
+### Tests for User Story 4 (write first, ensure they FAIL)
+
+- [ ] T006 [P] [US4] Extend `src/core/__tests__/page-config.test.ts` — `tables` parsing: valid entries, missing/empty `selector` dropped, `enrichments` normalisation, `startActive` coercion, malformed `tables` warn-and-ignore
+- [ ] T007 [P] [US4] Create `src/core/__tests__/per-table-options.test.ts` — selector matching (id `#x` and CSS `.cls`/structural), declaration-order **last-match-wins per field** (R-7), `data-gs-ignore` excluded (R-8), no-match returns `matched:false`
+- [ ] T008 [P] [US4] Extend `src/core/__tests__/effective-enabled-set.test.ts` — per-table tier precedence (visitor > per-table > page > defaults) and unknown-id drop at the per-table tier (INV-2)
+- [ ] T009 [P] [US4] Create `src/ui/__tests__/header-utils.per-table.test.ts` — two tables with different per-table enrichment sets receive different lozenge clusters; an unmatched table matches today's global behaviour (INV-1)
+
+### Implementation for User Story 4
+
+- [ ] T010 [US4] Add a `perTableEnrichments?: Set<string>` tier to `resolveEnabledSet` in `src/core/effective-enabled-set.ts`: visitor wins, else per-table (intersected with known ids), else page, else defaults (R-3, contract §2)
+- [ ] T011 [US4] Implement `src/core/per-table-options.ts`: `matchTableEntries(table, entries)` via `Element.matches`, fold last-match-wins per field, and `resolveTableConfig(table)` returning `{enrichments, startActive, matched}` (depends on T004, T010)
+- [ ] T012 [US4] Make `src/core/enabled-set-state.ts` table-aware: store parsed `tables`; add optional `table` arg to `getEffectiveEnabledSet`/`isEnrichmentEnabled`; cache `ResolvedTableConfig` in a `WeakMap`; invalidate cache on `setPageConfig`/`setVisitorOverride` (R-4, contract §3) (depends on T011)
+- [ ] T013 [US4] Pass the in-scope `table` to `getEffectiveEnabledSet(table)` in `src/ui/header-utils.ts` (`addLozengesToHeader`) so injection is per-table (depends on T012)
+- [ ] T014 [US4] In `src/index.ts`: wire `init()` to set the parsed `tables` into `enabled-set-state`, and pass `table` to the `isEnrichmentEnabled('outlier'|'freeze-panes'|'summary-row', table)` auto-render gates (depends on T012)
+- [ ] T015 [US4] Audit `isEnrichmentEnabled(id)` callers in `src/enrichments/slider.ts`, `slider-threshold.ts`, `annotations.ts`: pass `table` where the decision is table-scoped, leave page-global where intended; add a brief comment noting which (depends on T012)
+
+**Checkpoint**: Two tables on one page expose different enrichment sets driven
+solely by per-table options (SC-005); unmatched tables unchanged (SC-009).
+
+---
+
+## Phase 4: User Story 1 - First-time visitor understands what Grid-Sight is (Priority: P1)
+
+**Goal**: A cold visitor reads, in plain language, what Grid-Sight is, the
+problem it solves, and its principles — before any demo.
+
+**Independent Test**: Load the page with Grid-Sight disabled; the hero +
+principles section communicates purpose and principles without interacting with
+any table.
+
+### Tests for User Story 1
+
+- [ ] T016 [P] [US1] In `e2e/welcome-per-table.spec.ts`, add a US1 test: hero heading + problem statement + all five principles are present and visible with Grid-Sight disabled (FR-001, FR-002)
+
+### Implementation for User Story 1
+
+- [ ] T017 [US1] Rewrite the top of `public/index.html`: replace the sliders-only lede with a hero (what GS is + problem it solves) and a plain-language principles block (offline/air-gapped, zero deps, progressive, accessible, byte-identical teardown), per `contracts/welcome-page.md` §1
+- [ ] T018 [US1] Add the welcome-page CSS for the hero/principles (warm-but-technical styling), keeping it inline and offline-safe (no fetched fonts/icons)
+
+**Checkpoint**: Intro reads well standalone (SC-001); page still loads offline.
+
+---
+
+## Phase 5: User Story 2 - Visitor experiments with features inline (Priority: P1)
+
+**Goal**: Four feature sections, each narrative beside a live demo table,
+alternating sides on wide screens and stacking on mobile, each linking to its
+demo pages.
+
+**Independent Test**: Scroll through and operate each section's table; layout
+alternates on wide screens and stacks on narrow screens.
+
+**Depends on**: US4 (per-table options drive each demo's distinct feature set).
+
+### Tests for User Story 2
+
+- [ ] T019 [P] [US2] Create `src/stories/per-table-options.stories.ts` — a Storybook story composing two tables with distinct enrichment sets + one start-active/one start-inactive, with a `play` interaction asserting different lozenges appear
+- [ ] T020 [P] [US2] In `e2e/welcome-per-table.spec.ts`, add US2 tests: all four feature areas have a live operable table; two tables show different lozenge sets simultaneously (SC-005); wide-screen alternation (CSS order) and mobile stacking with no horizontal overflow (SC-003); each section links to its demo page(s) (FR-008)
+
+### Implementation for User Story 2
+
+- [ ] T021 [US2] Add the four feature sections to `public/index.html` (sliders & interpolation; visual analysis; navigation & search; derived data & notes), each: heading + narrative + ≥1 demo table with a stable `id` + links to the area's existing demo pages (FR-003, FR-006, FR-007, FR-008)
+- [ ] T022 [US2] Add the alternating two-column CSS grid + mobile `@media` stacking, alternation via CSS `order`/`:nth-of-type` only so DOM/tab order stays narrative-then-table (R-10, FR-004, FR-005, a11y)
+- [ ] T023 [US2] Configure `window.gridSight.pageConfig.tables` in `public/index.html` so each demo table offers exactly its section's enrichment(s) and starts active; re-register the slider demo's formula once the IIFE loads (R-11, contract §1)
+
+**Checkpoint**: All four areas operable inline; distinct sets co-resident; layout
+responsive (US2 complete, builds on US4).
+
+---
+
+## Phase 6: User Story 3 - On/off and start-state explained and demonstrated (Priority: P2)
+
+**Goal**: Keep+explain the global toggle (non-destructive overlay) and
+demonstrate the per-table start-state by showing a start-active table beside a
+start-inactive one, each flippable in place.
+
+**Independent Test**: Toggle the global control and watch the page move between
+attached and raw; confirm one table loads with enrichments revealed and one
+hidden, and clicking a GS toggle flips it without reload.
+
+**Depends on**: US4 (resolved start-state) and US2 (section layout to host the demo).
+
+### Tests for User Story 3
+
+- [ ] T024 [P] [US3] Create `src/ui/__tests__/toggle-injector.start-state.test.ts` — `activateToggle`/`deactivateToggle`: active class + `aria-expanded` flip, plus-icons injected/removed, and **byte-identical teardown** after activate→deactivate (FR-024, INV-4)
+- [ ] T025 [P] [US3] In `e2e/welcome-per-table.spec.ts`, add US3 tests: one table starts active (lozenges visible on load) and one starts inactive; clicking a GS toggle reveals/hides in place; global toggle off→on restores each table to its configured start-state (FR-009–FR-011, R-6)
+
+### Implementation for User Story 3
+
+- [ ] T026 [US3] Extract `activateToggle(table)`/`deactivateToggle(table)` from the inline click handler in `src/ui/toggle-injector.ts` and have the click handler call them (single shared path; export both) (R-5, contract §4)
+- [ ] T027 [US3] In `src/index.ts`, after `injectToggle(table)`, call `activateToggle(table)` iff `resolveTableConfig(table).startActive`; on global re-enable, re-apply each table's configured start-state (R-5, R-6) (depends on T026, T012)
+- [ ] T028 [US3] In `public/index.html`, add the global-toggle region with narrative framing it as a non-destructive overlay, and place a start-active table beside a start-inactive one as the live start-state contrast (FR-009, FR-011, contract §1 items 3–4)
+
+**Checkpoint**: Global toggle round-trips and is explained; start-state contrast
+visible and interactive (SC-004, SC-008).
+
+---
+
+## Phase 7: User Story 5 - Visitor can still reach every existing demo (Priority: P3)
+
+**Goal**: All 12 existing demo pages remain reachable from the welcome page.
+
+**Independent Test**: From the welcome page, every existing demo page is reachable
+via a working link.
+
+### Tests for User Story 5
+
+- [ ] T029 [P] [US5] In `e2e/welcome-per-table.spec.ts`, add a US5 test asserting every existing demo page URL (the 12 from today's grid) is linked and the links resolve (no orphaned demo) (FR-012, SC-006)
+
+### Implementation for User Story 5
+
+- [ ] T030 [US5] Add a consolidated "more demos" index section near the bottom of `public/index.html` linking all 12 existing demo pages (preserving today's reachable set), complementing the per-section links from US2 (FR-012)
+
+**Checkpoint**: Zero orphaned demos (SC-006).
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Budget, docs, and whole-feature validation.
+
+- [ ] T031 Measure bundle delta with `node scripts/bundle-size.js --soft`; confirm < 42 KB gz and within the ≤ 1.5 KB budget; if breached, note explicitly in the PR (constitution §I)
+- [ ] T032 [P] Document the per-table options API + start-state in `docs/` (and a short note in `docs/architecture/enrichments.md` that gating is now table-aware); reconcile `README.md` feature list if it claims page-only config
+- [ ] T033 [P] Add an offline/`file://` smoke assertion to `e2e/welcome-per-table.spec.ts` (or a manual step in `quickstart.md`) confirming the page + every inline demo work with no network (FR-013, SC-007)
+- [ ] T034 Run full suites green: `yarn test` (Vitest + Storybook), `yarn test:e2e` (Playwright), `yarn build` (tsc, zero errors) — the merge gate (constitution §II, SC-009)
+- [ ] T035 Walk `quickstart.md` end-to-end against the built page; fix any drift between the documented contract and actual behaviour
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: no dependencies — start immediately.
+- **Foundational (Phase 2)**: depends on Setup — blocks US4.
+- **US4 (Phase 3)**: depends on Foundational — the enabling capability; blocks US2 and US3.
+- **US1 (Phase 4)**: depends only on Setup — page-only, can run any time after Setup (parallel with US4).
+- **US2 (Phase 5)**: depends on US4 (and US1's page shell is convenient but not strictly required).
+- **US3 (Phase 6)**: depends on US4 (start-state) and US2 (section to host the demo).
+- **US5 (Phase 7)**: depends only on the page existing — independent of US4.
+- **Polish (Phase 8)**: depends on all targeted stories.
+
+### Story independence
+
+- **US4** is independently testable (unit + jsdom) without any page work.
+- **US1** and **US5** are pure page content, independently testable, and need none of the API.
+- **US2/US3** are the integration of the API into the page.
+
+### Within each story
+
+- Tests written first and expected to FAIL before implementation.
+- Core resolution (T010–T012) before consumers (T013–T015).
+- Toggle extraction (T026) before start-state wiring (T027) before the page demo (T028).
+
+### Parallel opportunities
+
+- T002, T003 (Setup) in parallel.
+- US4 tests T006–T009 in parallel (different files).
+- US1 (Phase 4) can proceed in parallel with US4 (Phase 3) — different files (`public/index.html` vs `src/core`/`src/ui`).
+- US5 (Phase 7) can proceed in parallel once the page shell exists.
+- Polish T032, T033 in parallel.
+
+---
+
+## Parallel Example: User Story 4 tests
+
+```bash
+# Launch all US4 tests together (different files), expect them to FAIL first:
+Task: "Extend page-config.test.ts for tables parsing"          # T006
+Task: "Create per-table-options.test.ts (matching + fold)"     # T007
+Task: "Extend effective-enabled-set.test.ts (per-table tier)"  # T008
+Task: "Create header-utils.per-table.test.ts (two tables)"     # T009
+```
+
+---
+
+## Implementation Strategy
+
+### MVP scope
+
+The smallest valuable slice is **US4 (per-table options API)** plus **US1
+(intro)**: the engine that makes distinct inline demos possible, and the broad
+welcome framing. Complete Phases 1–4, validate US4 unit/jsdom + US1 e2e, then
+layer US2 (inline demos), US3 (toggle/start-state), and US5 (all-demos index).
+
+### Incremental delivery
+
+1. Setup + Foundational → config accepts `tables`.
+2. US4 → two tables show different features (capability proven, unit/jsdom green).
+3. US1 → page reads as a real welcome (offline).
+4. US2 → the four inline alternating demos go live on the page.
+5. US3 → global toggle explained + start-state contrast demonstrated.
+6. US5 → all demos remain reachable.
+7. Polish → bundle budget, docs, full suites green, quickstart walk-through.
+
+### Notes
+
+- [P] = different files, no incomplete dependencies.
+- Commit after each task or logical group; keep teardown byte-identical at every step.
+- Do not regress unmatched-table behaviour (INV-1) — it is the no-regression guard.


### PR DESCRIPTION
## Summary

Captures, as a formal Spec Kit feature, the requirements gathered from an interview about turning the Grid-Sight landing page into a **broad welcome** rather than a sliders-demo index. This PR contains the **specification only** (`specs/015-welcome-per-table-options/`) — no implementation yet. It is the requirements artifact for review before `/speckit-clarify` → `/speckit-plan`.

## What the feature will do

**Welcome page (`public/index.html`)**
- Open with a plain-language hero + principles intro (what Grid-Sight is, the problem it solves, and its principles: offline/air-gapped, zero runtime deps, progressive enhancement, accessibility, byte-identical teardown).
- Present all four feature areas as **alternating two-column rows** — narrative on one side, a **live interactive table** on the other — stacking to one column on mobile, each linking to its related demo pages.
- Keep the global enable/disable toggle but **explain it in the narrative** (non-destructive overlay), and **demonstrate live** a table that starts in the raw state.
- Retain links to all existing demo pages.

**New platform capability — per-table options**
- Scope enrichments to specific tables addressed by **id or CSS selector** (today config is strictly page-level; only `data-gs-ignore` is per-table).
- Add a **per-table start-state** (begin enabled or disabled, **default off**).
- Resolution precedence: **visitor override > per-table > page-level > library defaults**; unknown ids dropped; `data-gs-ignore` still wins.
- **Additive / non-breaking**: existing consumers' tables continue to enrich on load as today.

## Key decisions captured (from the interview)

- Audience: general/mixed first-time visitors; goal: understand *what GS is & why it matters*; tone: technical but warmer.
- Layout: alternating narrative/table rows (not iframes); per-table differences powered by a real new API, not faked.
- Global default behaviour is **not** flipped — "default off" is the per-table start-state option only.

## Open assumptions for reviewers

Two decisions were resolved as documented Assumptions rather than blocking the spec:
1. Interaction between the global enable control and per-table start-state.
2. Last-match-wins for overlapping per-table selectors.

If you'd prefer these locked down before planning, `/speckit-clarify` is the natural next step.

## Notes

- Developed on the pre-assigned session branch `claude/welcome-page-redesign-rVjHn`; the `015` spec directory number is for sequential cataloguing only.
- No code changes — spec + quality checklist only.

https://claude.ai/code/session_019YwundeY8YrT3fyRWBNdzD

---
_Generated by [Claude Code](https://claude.ai/code/session_019YwundeY8YrT3fyRWBNdzD)_