### PR TITLE
Make demo pages mobile-responsive

### DIFF
--- a/public/demo/annotations/annotations-doc-a.html
+++ b/public/demo/annotations/annotations-doc-a.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Report A</title>
   <style>
     body { font-family: system-ui, sans-serif; max-width: 900px; margin: 24px auto; padding: 0 16px; color: #222; }

--- a/public/demo/annotations/annotations-doc-b.html
+++ b/public/demo/annotations/annotations-doc-b.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Report B</title>
   <style>
     body { font-family: system-ui, sans-serif; max-width: 900px; margin: 24px auto; padding: 0 16px; color: #222; }

--- a/public/demo/annotations/single.html
+++ b/public/demo/annotations/single.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Grid-Sight · Annotations · Single table</title>
   <style>
     body { font-family: system-ui, sans-serif; max-width: 900px; margin: 24px auto; padding: 0 16px; color: #222; }

--- a/public/demo/annotations/two-tables.html
+++ b/public/demo/annotations/two-tables.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Grid-Sight · Annotations · Two tables</title>
   <style>
     body { font-family: system-ui, sans-serif; max-width: 900px; margin: 24px auto; padding: 0 16px; color: #222; }

--- a/public/demo/capability-filtering/fixture.html
+++ b/public/demo/capability-filtering/fixture.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Capability filtering e2e fixture</title>
   <style>
     body { font-family: system-ui, sans-serif; max-width: 720px; margin: 24px auto; padding: 0 16px; color: #222; }

--- a/public/demo/outlier/measurements.html
+++ b/public/demo/outlier/measurements.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Grid-Sight · Outlier Marker · Measurements</title>
   <style>
     body { font-family: system-ui, sans-serif; max-width: 900px; margin: 24px auto; padding: 0 16px; color: #222; }

--- a/public/demo/row-visibility/orders.html
+++ b/public/demo/row-visibility/orders.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Grid-Sight · Row Visibility · Orders</title>
   <style>
     body { font-family: system-ui, sans-serif; max-width: 900px; margin: 24px auto; padding: 0 16px; color: #222; }

--- a/public/demo/row-visibility/perf-1000.html
+++ b/public/demo/row-visibility/perf-1000.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="UTF-8"><title>Row Visibility · 1000-row perf fixture</title>
+<html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>Row Visibility · 1000-row perf fixture</title>
 <style>
   body { font-family: system-ui, sans-serif; max-width: 900px; margin: 24px auto; padding: 0 16px; }
   table { border-collapse: collapse; width: 100%; }

--- a/public/demo/sliders/alternate-calc-models.html
+++ b/public/demo/sliders/alternate-calc-models.html
@@ -2,11 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Grid-Sight · Slider · Alternate Calculation Models (Story 2)</title>
   <style>
     body { font-family: system-ui, sans-serif; max-width: 1100px; margin: 24px auto; padding: 0 16px; color: #222; }
     h1 { margin-top: 0; }
     .pair { display: grid; grid-template-columns: 1fr 1fr; gap: 32px; }
+    @media (max-width: 760px) { .pair { grid-template-columns: 1fr; gap: 24px; } }
     table { border-collapse: collapse; width: 100%; }
     th, td { border: 1px solid #ccc; padding: 6px 10px; text-align: right; font-variant-numeric: tabular-nums; }
     thead th { background: #f4f4f4; }

--- a/public/demo/sliders/heatmap.html
+++ b/public/demo/sliders/heatmap.html
@@ -2,11 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Grid-Sight · Slider · Dynamic Heatmap (Story 4)</title>
   <style>
     body { font-family: system-ui, sans-serif; max-width: 1100px; margin: 24px auto; padding: 0 16px; color: #222; }
     h1 { margin-top: 0; }
     .pair { display: grid; grid-template-columns: 1fr 1fr; gap: 32px; }
+    @media (max-width: 760px) { .pair { grid-template-columns: 1fr; gap: 24px; } }
     .panel { position: relative; }
     table { border-collapse: collapse; width: 100%; }
     th, td { border: 1px solid #ccc; padding: 6px 10px; text-align: right; font-variant-numeric: tabular-nums; }

--- a/public/demo/sliders/interpolation.html
+++ b/public/demo/sliders/interpolation.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Grid-Sight · Slider · Interpolation Demo (Story 1)</title>
   <style>
     body { font-family: system-ui, sans-serif; max-width: 960px; margin: 24px auto; padding: 0 16px; color: #222; }

--- a/public/demo/sliders/synced-tables.html
+++ b/public/demo/sliders/synced-tables.html
@@ -2,11 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Grid-Sight · Slider · Synced Persistent Tables (Story 3)</title>
   <style>
     body { font-family: system-ui, sans-serif; max-width: 1100px; margin: 24px auto; padding: 0 16px; color: #222; }
     h1 { margin-top: 0; }
     .pair { display: grid; grid-template-columns: 1fr 1fr; gap: 32px; }
+    @media (max-width: 760px) { .pair { grid-template-columns: 1fr; gap: 24px; } }
     table { border-collapse: collapse; width: 100%; }
     th, td { border: 1px solid #ccc; padding: 6px 10px; text-align: right; font-variant-numeric: tabular-nums; }
     thead th { background: #f4f4f4; }

--- a/public/demo/toggle/live-enrichments.html
+++ b/public/demo/toggle/live-enrichments.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Grid-Sight · Live enrichment toggles (spec 012)</title>
   <style>
     body { font-family: system-ui, sans-serif; max-width: 960px; margin: 24px auto; padding: 0 16px; color: #222; }

--- a/public/demo/toggle/opt-in-playground.html
+++ b/public/demo/toggle/opt-in-playground.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Grid-Sight · Opt-in playground</title>
   <style>
     body { font-family: system-ui, sans-serif; max-width: 1024px; margin: 24px auto; padding: 0 16px; color: #222; }

--- a/public/demo/toggle/vc-panel-fixture.html
+++ b/public/demo/toggle/vc-panel-fixture.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Grid-Sight · e2e fixture · VC + toggle panel</title>
   <style>
     body { font-family: system-ui, sans-serif; margin: 24px; }


### PR DESCRIPTION
## Summary

The welcome page (`public/index.html`) is mobile-friendly, but the demo pages under `public/demo/` were not. This PR makes them reflow correctly on mobile.

## Root cause

Every affected demo page was **missing the `<meta name="viewport">` tag**. Without it, mobile browsers assume a ~980px desktop viewport and render the whole page zoomed out — nothing reflows. On the toggle/freeze-style pages this was doubly broken: they already had `@media` stacking rules, but those rules never fired because the real device width was never reported to the browser.

A secondary issue: the three slider **"pair"** demos used a hardcoded two-column grid (`.pair { grid-template-columns: 1fr 1fr }`) that never collapsed, so two side-by-side tables couldn't fit a phone even with a viewport tag.

## Changes

- Added `<meta name="viewport" content="width=device-width, initial-scale=1.0">` to every demo page that lacked it:
  - `sliders/interpolation.html`, `sliders/alternate-calc-models.html`, `sliders/synced-tables.html`, `sliders/heatmap.html`
  - `toggle/live-enrichments.html`, `toggle/opt-in-playground.html`, `toggle/vc-panel-fixture.html`
  - `outlier/measurements.html`
  - `annotations/single.html`, `annotations/two-tables.html`, `annotations/annotations-doc-a.html`, `annotations/annotations-doc-b.html`
  - `row-visibility/orders.html`, `row-visibility/perf-1000.html`
  - `capability-filtering/fixture.html`
- Added a stacking `@media (max-width: 760px) { .pair { grid-template-columns: 1fr } }` rule to the three slider "pair" demos (breakpoint matches the existing `freeze-panes` / `summary-row` / `find-in-table` pages).

## Notes

- Pages that already reflowed correctly were left untouched: `virtual-columns.html`, `annotations/index.html`, `statistics/index.html`, `summary-row/index.html`, `find-in-table/index.html`, `freeze-panes/index.html`, and the `cube-css.html` hero — all already carry a viewport tag (and stacking media queries where needed).
- `annotations/embed-snippet.html` is intentionally **not** changed: its code comment marks it as a verbatim mirror of the spec-006 quickstart embed snippet, and it is a non-browseable e2e fixture.
- Changes are purely additive (a meta tag and a CSS media query); no JS, no DOM structure, and no enrichment behaviour is affected.

https://claude.ai/code/session_01P6JrdZ3pbcCW2eJaAny8Xw

---
_Generated by [Claude Code](https://claude.ai/code/session_01P6JrdZ3pbcCW2eJaAny8Xw)_