### PR TITLE
test(sync-key): pin note-annotated header parsing

### DIFF
--- a/src/utils/__tests__/sync-key.test.ts
+++ b/src/utils/__tests__/sync-key.test.ts
@@ -17,6 +17,21 @@ describe('parseHeaderNumber', () => {
     expect(parseHeaderNumber('25kg')).toBe(25);
   });
 
+  it('ignores trailing note annotations after a unit-suffixed value', () => {
+    // Real-world speed axis: "1kt", "2kt", … "120kt (Note 1)", "121kt (Note 2)".
+    // Only the leading numeric prefix is significant; unit + parenthetical note are discarded.
+    expect(parseHeaderNumber('3kt')).toBe(3);
+    expect(parseHeaderNumber('120kt (Note 1)')).toBe(120);
+    expect(parseHeaderNumber('121kt (Note 2)')).toBe(121);
+  });
+
+  it('returns null when text precedes the number', () => {
+    // The numeric run must be anchored at the start of the cell — a leading note
+    // (rather than a trailing one) disqualifies the header.
+    expect(parseHeaderNumber('Note 1: 120kt')).toBeNull();
+    expect(parseHeaderNumber('~120kt')).toBeNull();
+  });
+
   it('returns null for non-numeric headers', () => {
     expect(parseHeaderNumber('alpha')).toBeNull();
     expect(parseHeaderNumber('')).toBeNull();
@@ -35,6 +50,14 @@ describe('deriveSyncKey', () => {
 
   it('returns null when any header is non-numeric', () => {
     expect(deriveSyncKey(['10', 'twenty', '30'])).toBeNull();
+  });
+
+  it('accepts a speed axis whose headers carry unit suffixes and note annotations', () => {
+    // Whole axis must parse for the table to qualify for interpolation.
+    const speedHeaders = ['1kt', '2kt', '3kt', '120kt (Note 1)', '121kt (Note 2)'];
+    expect(deriveSyncKey(speedHeaders)).not.toBeNull();
+    // Note text is irrelevant to the derived key: annotated headers sync with plain ones.
+    expect(deriveSyncKey(speedHeaders)).toBe(deriveSyncKey(['1', '2', '3', '120', '121']));
   });
 
   it('returns null for degenerate (single-value) axes', () => {


### PR DESCRIPTION
## Summary

A user reported a temperature-vs-speed table whose column headers combine a unit suffix with a parenthetical note — e.g. `1kt`, `2kt`, … `120kt (Note 1)`, `121kt (Note 2)` — and asked whether the `(Note …)` text would prevent Grid-Sight from recognising the axis for interpolation.

It does **not**. `parseHeaderNumber` (`src/utils/sync-key.ts`) already reads the leading numeric run and discards everything after it (unit + note), so every header parses to a number and the axis still qualifies via the `buildAxisBinding` gate. This PR pins that behaviour with tests so it can't regress.

## Changes

Adds cases to `src/utils/__tests__/sync-key.test.ts`:

- **Trailing note annotations** — `parseHeaderNumber('120kt (Note 1)') === 120`, `'121kt (Note 2)' === 121`, `'3kt' === 3`. The unit and parenthetical note are ignored.
- **Failure boundary** — a note that *precedes* the number disqualifies the header: `parseHeaderNumber('Note 1: 120kt')` and `'~120kt'` both return `null` (the numeric run must be anchored at the start of the cell).
- **Axis-level** — a full speed axis with mixed plain/annotated headers derives the same sync key as its plain-number equivalent (`deriveSyncKey(['1kt','2kt','3kt','120kt (Note 1)','121kt (Note 2)']) === deriveSyncKey(['1','2','3','120','121'])`), confirming the whole axis qualifies for interpolation.

## Testing

`npx vitest run src/utils/__tests__/sync-key.test.ts` — 14 passed (3 new). No production code changed; this is a characterisation/regression-guard addition only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3DSSA4X5n3xcHBbyvDqdi

---
_Generated by [Claude Code](https://claude.ai/code/session_01M3DSSA4X5n3xcHBbyvDqdi)_