### PR TITLE
feat(sliders): support interpolation on merged/banner header tables

### DIFF
--- a/public/demo/nav.js
+++ b/public/demo/nav.js
@@ -27,7 +27,8 @@
     { path: 'find-in-table/index.html', label: '12. Find in table' },
     { path: 'matrix/index.html', label: '13. Matrix fixture' },
     { path: 'copy-as-csv/index.html', label: '14. Copy as CSV' },
-    { path: 'twin-table/index.html', label: '15. Twin table (investigation)' }
+    { path: 'twin-table/index.html', label: '15. Twin table (investigation)' },
+    { path: 'sliders/merged-headers.html', label: '16. Merged headers' }
   ];
 
   var STYLE_ID = 'gs-demo-nav-styles';

--- a/public/demo/sliders/merged-headers.html
+++ b/public/demo/sliders/merged-headers.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Grid-Sight · Slider · Merged / banner headers</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 960px; margin: 24px auto; padding: 0 16px; color: #222; }
+    h1 { margin-top: 0; }
+    h2 { margin-top: 32px; }
+    table { border-collapse: collapse; margin-top: 8px; }
+    th, td { border: 1px solid #ccc; padding: 6px 10px; text-align: right; font-variant-numeric: tabular-nums; }
+    thead th { background: #f4f4f4; }
+    /* The merged banner cell reads as a title row. */
+    thead th[colspan] { text-align: center; font-weight: 600; background: #eef2f7; }
+    p.hint { color: #555; }
+    code { background: #f4f4f4; padding: 1px 4px; border-radius: 3px; }
+  </style>
+</head>
+<body>
+  <nav data-gs-demo-nav></nav>
+
+  <h1>Slider · Merged / banner headers</h1>
+  <p class="hint">
+    Speed-vs-length matrix tables often carry a merged <strong>&ldquo;Length Overall (m)&rdquo;</strong>
+    banner above the numeric column headers. Grid-Sight peels off the banner and
+    binds interpolation to the <em>leaf</em> header row, so both author
+    permutations below offer the sliders. Click the <strong>GS</strong> toggle,
+    open the <strong>+</strong> on the top-left corner cell, choose
+    <strong>Sliders</strong>, then drag either axis to interpolate — the
+    bracketing four cells highlight live.
+  </p>
+
+  <h2>Permutation 1 — full-width <code>colspan</code> banner</h2>
+  <p class="hint">
+    A single merged cell spans the whole header; the leaf row still carries the
+    <strong>Speed Knots</strong> corner alongside the length headers.
+  </p>
+  <table id="perm1-colspan-banner"></table>
+
+  <h2>Permutation 2 — <code>rowspan</code> corner + <code>colspan</code> banner</h2>
+  <p class="hint">
+    <strong>Speed Knots</strong> spans both header rows, so the leaf row is
+    <em>all</em> length headers (no corner cell) with its cells shifted right
+    under the rowspan. This is the case that previously blocked interpolation.
+  </p>
+  <table id="perm2-rowspan-corner"></table>
+
+  <script>
+    // Build both matrices BEFORE the bundle loads so Grid-Sight sees a complete
+    // table at init time. Lengths mirror the reported pattern (10→50 by 10, then
+    // to 90 by 20); speeds run 10→90 by 10. Cell = smooth f(speed, length) so
+    // interpolation + heatmap read sensibly.
+    (function () {
+      var LENGTHS = [10, 20, 30, 40, 50, 70, 90];
+      var SPEEDS = [10, 20, 30, 40, 50, 60, 70, 80, 90];
+      function cell(speed, len) {
+        return (len * 0.12 + speed * 0.05).toFixed(1);
+      }
+
+      function bodyRows() {
+        var out = '';
+        for (var i = 0; i < SPEEDS.length; i++) {
+          var s = SPEEDS[i];
+          out += '<tr><th>' + s + '</th>';
+          for (var j = 0; j < LENGTHS.length; j++) {
+            out += '<td>' + cell(s, LENGTHS[j]) + '</td>';
+          }
+          out += '</tr>';
+        }
+        return out;
+      }
+
+      function leafHeaderCells() {
+        var out = '';
+        for (var j = 0; j < LENGTHS.length; j++) out += '<th>' + LENGTHS[j] + '</th>';
+        return out;
+      }
+
+      // Permutation 1: banner spans the corner + every length column.
+      document.getElementById('perm1-colspan-banner').innerHTML =
+        '<thead>' +
+        '<tr><th colspan="' + (LENGTHS.length + 1) + '">Length Overall (m)</th></tr>' +
+        '<tr><th>Speed Knots</th>' + leafHeaderCells() + '</tr>' +
+        '</thead>' +
+        '<tbody>' + bodyRows() + '</tbody>';
+
+      // Permutation 2: rowspan corner beside a banner spanning only the lengths.
+      document.getElementById('perm2-rowspan-corner').innerHTML =
+        '<thead>' +
+        '<tr><th rowspan="2">Speed Knots</th>' +
+        '<th colspan="' + LENGTHS.length + '">Length Overall (m)</th></tr>' +
+        '<tr>' + leafHeaderCells() + '</tr>' +
+        '</thead>' +
+        '<tbody>' + bodyRows() + '</tbody>';
+    })();
+
+    // Offer heatmap + sliders + statistics on this page.
+    window.gridSight = { pageConfig: { enrichments: ['heatmap', 'sliders', 'statistics'] } };
+  </script>
+  <script src="../../grid-sight.iife.js"></script>
+  <script src="../nav.js"></script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -223,6 +223,7 @@
         <p class="demo-links">
           <a href="demo/sliders/interpolation.html">Interpolation demo →</a>
           <a href="demo/sliders/alternate-calc-models.html">Calc models →</a>
+          <a href="demo/sliders/merged-headers.html">Merged headers →</a>
         </p>
       </div>
       <div class="feature__demo">
@@ -398,6 +399,10 @@
         <a class="demo-card" href="demo/sliders/synced-tables.html">
           <h3>Persistent URL</h3>
           <p>Slider positions encoded in the URL fragment — bookmark, share, or reload at a value.</p>
+        </a>
+        <a class="demo-card" href="demo/sliders/merged-headers.html">
+          <h3>Merged headers</h3>
+          <p>Interpolation on a speed-vs-length matrix with a merged banner header — colspan banner and rowspan corner.</p>
         </a>
         <a class="demo-card" href="demo/toggle/live-enrichments.html">
           <h3>Live toggles — all on</h3>

--- a/src/core/__tests__/table-grid.test.ts
+++ b/src/core/__tests__/table-grid.test.ts
@@ -15,6 +15,7 @@ import {
   isVirtualColumn,
   gridRows,
   headerRow,
+  headerRows,
   bodyRows,
   gridCells,
   sourceCells,
@@ -23,6 +24,7 @@ import {
   cellAt,
   columnCells,
   headerCellFor,
+  dataHeaderCells,
   logicalColIndexOf,
   logicalRowIndexOf,
   cellValue,
@@ -121,6 +123,83 @@ describe('row access', () => {
     expect(gridCells(headerRow(table)!)[0].textContent).toBe('GS');
     expect(bodyRows(table)).toHaveLength(3);
     for (const r of gridRows(table)) expect(isScaffold(r)).toBe(false);
+  });
+});
+
+/* ── Merged / banner headers ────────────────────────────────────────── */
+
+describe('merged banner headers', () => {
+  it('picks the leaf header row past a full-width banner (permutation 1)', () => {
+    const table = document.createElement('table');
+    table.innerHTML = `
+      <thead>
+        <tr><th colspan="4">Length Overall (m)</th></tr>
+        <tr><th>Speed Knots</th><th>10</th><th>20</th><th>30</th></tr>
+      </thead>
+      <tbody>
+        <tr><th>10</th><td>1</td><td>2</td><td>3</td></tr>
+        <tr><th>20</th><td>4</td><td>5</td><td>6</td></tr>
+      </tbody>
+    `;
+    document.body.appendChild(table);
+    expect(headerRow(table)!.cells[0].textContent).toBe('Speed Knots');
+    expect(headerRows(table)).toHaveLength(2);
+    expect(bodyRows(table)).toHaveLength(2);
+    // Column headers drop the corner label, keep the numeric leaf headers.
+    expect(dataHeaderCells(table).map((c) => c.textContent)).toEqual([
+      '10',
+      '20',
+      '30',
+    ]);
+  });
+
+  it('resolves a rowspan corner + banner: leaf cells are shifted right (permutation 2)', () => {
+    const table = document.createElement('table');
+    table.innerHTML = `
+      <thead>
+        <tr><th rowspan="2">Speed Knots</th><th colspan="3">Length Overall (m)</th></tr>
+        <tr><th>10</th><th>20</th><th>30</th></tr>
+      </thead>
+      <tbody>
+        <tr><th>10</th><td>1</td><td>2</td><td>3</td></tr>
+        <tr><th>20</th><td>4</td><td>5</td><td>6</td></tr>
+      </tbody>
+    `;
+    document.body.appendChild(table);
+    // Leaf row is the numeric header row; it has NO corner cell of its own.
+    expect(headerRow(table)!.cells[0].textContent).toBe('10');
+    expect(headerRows(table)).toHaveLength(2);
+    // Occupancy-aware: none of the three leaf cells is dropped as a row label.
+    expect(dataHeaderCells(table).map((c) => c.textContent)).toEqual([
+      '10',
+      '20',
+      '30',
+    ]);
+  });
+
+  it('leaves a plain single-row header unchanged (dataHeaderCells == slice(1))', () => {
+    const { table } = buildNumericGrid();
+    const head = headerRow(table)!;
+    expect(headerRows(table)).toHaveLength(1);
+    expect(dataHeaderCells(table)).toEqual(sourceCells(head).slice(1));
+  });
+
+  it('skips a no-<thead> leading banner row', () => {
+    const table = document.createElement('table');
+    table.innerHTML = `
+      <tr><th></th><th colspan="3">Length Overall (m)</th></tr>
+      <tr><th>Speed Knots</th><th>10</th><th>20</th><th>30</th></tr>
+      <tr><th>10</th><td>1</td><td>2</td><td>3</td></tr>
+      <tr><th>20</th><td>4</td><td>5</td><td>6</td></tr>
+    `;
+    document.body.appendChild(table);
+    expect(headerRow(table)!.cells[1].textContent).toBe('10');
+    expect(bodyRows(table)).toHaveLength(2);
+    expect(dataHeaderCells(table).map((c) => c.textContent)).toEqual([
+      '10',
+      '20',
+      '30',
+    ]);
   });
 });
 

--- a/src/core/table-grid.ts
+++ b/src/core/table-grid.ts
@@ -75,7 +75,27 @@ function footerRowSet(table: HTMLTableElement): Set<HTMLTableRowElement> {
 }
 
 /**
- * Partition the non-scaffold rows into header + body.
+ * True when `row` is a merged "banner"/grouping super-header sitting above the
+ * real (leaf) column-header row: it has fewer logical cells than the row below
+ * it AND at least one of its cells spans multiple columns. The classic cases are
+ * a single `<th colspan="N">` title (e.g. "Length Overall (m)") drawn above the
+ * numeric column headers, and a corner label that spans down with `rowspan`. The
+ * colspan requirement guards against mistaking a genuinely short header/data row
+ * for a banner. `next` is the row immediately following, measured with the same
+ * source-cell rule so both counts are comparable.
+ */
+function isBannerRow(
+  row: HTMLTableRowElement,
+  next: HTMLTableRowElement,
+): boolean {
+  const cells = sourceCells(row);
+  if (cells.length >= sourceCells(next).length) return false;
+  return cells.some((c) => Math.max(1, c.colSpan || 1) > 1);
+}
+
+/**
+ * Resolve the header region into leading banner/grouping rows, the leaf
+ * column-header row, and the body rows.
  *
  * Mirrors the header-detection rule in
  * `src/utils/original-order.ts::getDataRows` (header is `table.rows[0]` iff it
@@ -85,8 +105,15 @@ function footerRowSet(table: HTMLTableElement): Set<HTMLTableRowElement> {
  * a `<th>` corner ahead of the real header, so running the heuristic over the
  * raw rows (as `getDataRows` does) would mistake that scaffold row for the
  * header. We mirror rather than reuse `getDataRows` for exactly this reason.
+ *
+ * Leading merged banner/grouping rows (a full-width `<th colspan="N">` title, or
+ * a `rowspan` corner + colspan banner above the numeric column headers) are
+ * peeled off so `header` is the LEAF column-header row that aligns 1:1 with the
+ * data columns. That is what lets sliders/interpolation bind to the numeric
+ * column headers rather than to the banner (see `isBannerRow`, `dataHeaderCells`).
  */
-function partitionRows(table: HTMLTableElement): {
+function resolveHeader(table: HTMLTableElement): {
+  banners: HTMLTableRowElement[];
   header: HTMLTableRowElement | null;
   body: HTMLTableRowElement[];
 } {
@@ -100,27 +127,138 @@ function partitionRows(table: HTMLTableElement): {
     : [];
 
   if (theadRows.length > 0) {
-    // Explicit head: header = first head row; body = all tbody data rows.
-    return { header: theadRows[0], body: tbodyRows };
+    // Explicit head: the leaf header is the LAST head row; any earlier rows are
+    // banner/grouping rows. body = all tbody data rows.
+    const leaf = theadRows.length - 1;
+    return {
+      banners: theadRows.slice(0, leaf),
+      header: theadRows[leaf],
+      body: tbodyRows,
+    };
   }
-  // No <thead>: the de-facto header is the first tbody row iff it has a <th>.
-  if (
-    tbodyRows.length > 0 &&
-    Array.from(tbodyRows[0].cells).some((c) => c.tagName === 'TH')
+  // No <thead>: peel off leading merged banner rows, then the de-facto header is
+  // the first remaining row iff it has a <th>.
+  let start = 0;
+  while (
+    start + 1 < tbodyRows.length &&
+    isBannerRow(tbodyRows[start], tbodyRows[start + 1])
   ) {
-    return { header: tbodyRows[0], body: tbodyRows.slice(1) };
+    start++;
   }
-  return { header: tbodyRows[0] ?? null, body: tbodyRows };
+  const first = tbodyRows[start];
+  if (first && Array.from(first.cells).some((c) => c.tagName === 'TH')) {
+    return {
+      banners: tbodyRows.slice(0, start),
+      header: first,
+      body: tbodyRows.slice(start + 1),
+    };
+  }
+  return { banners: [], header: tbodyRows[0] ?? null, body: tbodyRows };
 }
 
-/** The header row (first non-scaffold row; reuses original-order header rule). */
+/** The (leaf) header row: the row whose cells align 1:1 with the data columns.
+ *  Reuses the original-order header rule and peels off any merged banner rows. */
 export function headerRow(table: HTMLTableElement): HTMLTableRowElement | null {
-  return partitionRows(table).header;
+  return resolveHeader(table).header;
+}
+
+/** The full header block — leading banner/grouping rows followed by the leaf
+ *  column-header row — top-to-bottom, non-scaffold. Single-row headers return a
+ *  one-element array. */
+export function headerRows(table: HTMLTableElement): HTMLTableRowElement[] {
+  const { banners, header } = resolveHeader(table);
+  return header ? [...banners, header] : [];
 }
 
 /** Non-scaffold data rows after the header, excluding <tfoot>. Dimmed rows kept. */
 export function bodyRows(table: HTMLTableElement): HTMLTableRowElement[] {
-  return partitionRows(table).body;
+  return resolveHeader(table).body;
+}
+
+/**
+ * Occupancy-aware sweep of the header block (leading banner/grouping rows + the
+ * leaf column-header row), honouring both colspan and rowspan. Returns, for each
+ * logical SOURCE column, the header cell covering it AT the leaf row — which is
+ * the leaf cell itself, or a corner label that spans DOWN into the leaf row from
+ * a banner row (e.g. `<th rowspan="2">Speed Knots</th>`). Also reports which
+ * leaf-row cell (if any) originates each logical column, so the row-label
+ * column can be told apart from the data-column headers.
+ */
+function sweepHeaderColumns(table: HTMLTableElement): {
+  perColumn: HTMLTableCellElement[];
+  leafOriginCols: Set<number>;
+} {
+  const rows = headerRows(table);
+  if (rows.length === 0) return { perColumn: [], leafOriginCols: new Set() };
+  const leafIdx = rows.length - 1;
+  // grid[r][c] = the cell covering logical column c of header row r (from that
+  // row, or a rowspan spilling down from above).
+  const grid: (HTMLTableCellElement | undefined)[][] = rows.map(() => []);
+  const leafOriginCols = new Set<number>();
+  for (let r = 0; r < rows.length; r++) {
+    let c = 0;
+    for (const cell of sourceCells(rows[r])) {
+      while (grid[r][c]) c++;
+      const cs = Math.max(1, cell.colSpan || 1);
+      const rs = Math.max(1, cell.rowSpan || 1);
+      if (r === leafIdx) leafOriginCols.add(c);
+      for (let dr = 0; dr < rs && r + dr < rows.length; dr++) {
+        for (let dc = 0; dc < cs; dc++) grid[r + dr][c + dc] = cell;
+      }
+      c += cs;
+    }
+  }
+  const leaf = grid[leafIdx];
+  const perColumn: HTMLTableCellElement[] = [];
+  for (let c = 0; c < leaf.length; c++) if (leaf[c]) perColumn.push(leaf[c]!);
+  return { perColumn, leafOriginCols };
+}
+
+/**
+ * The header cell for every logical SOURCE column, in order — the row-label
+ * corner first, then one per data column. Occupancy-aware over a multi-row
+ * (banner) header. For a plain single-row header this equals `sourceCells`
+ * expanded by colspan; callers that need the untouched single-row behaviour
+ * should gate on `headerRows(table).length > 1`.
+ */
+export function sourceHeaderColumns(
+  table: HTMLTableElement,
+): HTMLTableCellElement[] {
+  return sweepHeaderColumns(table).perColumn;
+}
+
+/**
+ * The leaf header cells that head the DATA columns — every source cell of the
+ * leaf header row except the one in the leading row-label column.
+ *
+ * Occupancy-aware over the whole header block (colspan + rowspan): a corner
+ * label that spans DOWN into the leaf row from a banner row (e.g. a
+ * `<th rowspan="2">Speed Knots</th>` beside a `<th colspan="N">` banner) shifts
+ * the leaf row's cells to the right, so its first physical cell is correctly
+ * recognised as a data-column header rather than dropped as the row label. For a
+ * plain single-row header this is exactly `sourceCells(header).slice(1)`.
+ */
+export function dataHeaderCells(
+  table: HTMLTableElement,
+): HTMLTableCellElement[] {
+  const { perColumn, leafOriginCols } = sweepHeaderColumns(table);
+  // Logical column 0 is the row-label column. Keep the leaf-originated cells to
+  // its right (a corner that spans down from a banner row is not a leaf cell, so
+  // it is excluded automatically).
+  return perColumn.filter((_, col) => col >= 1 && leafOriginCols.has(col));
+}
+
+/**
+ * Author-text matrix aligned to logical SOURCE columns, for column-type
+ * detection / suitability on a table with a multi-row (banner) header. Row 0 is
+ * the leaf header aligned by logical column (occupancy-aware, so a rowspan
+ * corner keeps the numeric leaf headers in their true columns); the remaining
+ * rows are the body. Virtual columns are excluded.
+ */
+export function sourceColumnMatrix(table: HTMLTableElement): string[][] {
+  const header = sourceHeaderColumns(table).map(cellValue);
+  const body = bodyRows(table).map((row) => sourceCells(row).map(cellValue));
+  return [header, ...body];
 }
 
 /* ── Cells within a row ─────────────────────────────────────────────── */

--- a/src/core/type-detection.ts
+++ b/src/core/type-detection.ts
@@ -1,4 +1,10 @@
-import { gridRows, sourceCells, cellValue } from './table-grid';
+import {
+  gridRows,
+  sourceCells,
+  cellValue,
+  headerRows,
+  sourceColumnMatrix,
+} from './table-grid';
 
 /**
  * Type definitions for column type detection
@@ -227,6 +233,10 @@ export function analyzeTable(
  */
 export function extractTableData(table: HTMLTableElement): string[][] {
   if (!table.rows) return [];
+  // A multi-row (banner) header must be flattened by logical column so a merged
+  // banner row / rowspan corner doesn't collapse the column count and hide the
+  // table's numeric columns from type detection.
+  if (headerRows(table).length > 1) return sourceColumnMatrix(table);
   // Read author source cells via the canonical addressing layer: scaffold rows
   // and virtual columns are excluded and injected UI is stripped, so column-type
   // detection sees only author data regardless of active enrichments (013).

--- a/src/enrichments/__tests__/slider.test.ts
+++ b/src/enrichments/__tests__/slider.test.ts
@@ -64,6 +64,95 @@ describe('buildAxisBinding', () => {
     document.body.appendChild(tbl);
     expect(buildAxisBinding(tbl, 'col')).toBeNull();
   });
+
+  it('binds the column axis past a full-width merged banner row (permutation 1)', () => {
+    // A single merged banner cell drawn above the numeric column headers; the
+    // leaf header row still carries the "Speed Knots" corner + length headers.
+    const tbl = document.createElement('table');
+    tbl.innerHTML = `
+      <thead>
+        <tr><th colspan="4">Length Overall (m)</th></tr>
+        <tr><th>Speed Knots</th><th>10</th><th>20</th><th>30</th></tr>
+      </thead>
+      <tbody>
+        <tr><th>10</th><td>1</td><td>2</td><td>3</td></tr>
+        <tr><th>20</th><td>4</td><td>5</td><td>6</td></tr>
+        <tr><th>30</th><td>7</td><td>8</td><td>9</td></tr>
+      </tbody>
+    `;
+    document.body.appendChild(tbl);
+    const col = buildAxisBinding(tbl, 'col');
+    expect(col).not.toBeNull();
+    expect(col!.headerValues).toEqual([10, 20, 30]);
+    const row = buildAxisBinding(tbl, 'row');
+    expect(row).not.toBeNull();
+    expect(row!.headerValues).toEqual([10, 20, 30]);
+  });
+
+  it('binds the column axis with a rowspan corner + banner row (permutation 2)', () => {
+    // "Speed Knots" spans both header rows; the leaf row is ALL length headers
+    // (no corner cell to drop) and its cells are shifted right by the rowspan.
+    const tbl = document.createElement('table');
+    tbl.innerHTML = `
+      <thead>
+        <tr><th rowspan="2">Speed Knots</th><th colspan="3">Length Overall (m)</th></tr>
+        <tr><th>10</th><th>20</th><th>30</th></tr>
+      </thead>
+      <tbody>
+        <tr><th>10</th><td>1</td><td>2</td><td>3</td></tr>
+        <tr><th>20</th><td>4</td><td>5</td><td>6</td></tr>
+        <tr><th>30</th><td>7</td><td>8</td><td>9</td></tr>
+      </tbody>
+    `;
+    document.body.appendChild(tbl);
+    const col = buildAxisBinding(tbl, 'col');
+    expect(col).not.toBeNull();
+    expect(col!.headerValues).toEqual([10, 20, 30]);
+    const row = buildAxisBinding(tbl, 'row');
+    expect(row).not.toBeNull();
+    expect(row!.headerValues).toEqual([10, 20, 30]);
+  });
+});
+
+describe('sliders on merged-header tables', () => {
+  function bannerTable(): HTMLTableElement {
+    const tbl = document.createElement('table');
+    tbl.innerHTML = `
+      <thead>
+        <tr><th rowspan="2">Speed Knots</th><th colspan="3">Length Overall (m)</th></tr>
+        <tr><th>10</th><th>20</th><th>30</th></tr>
+      </thead>
+      <tbody>
+        <tr><th>10</th><td>1</td><td>2</td><td>3</td></tr>
+        <tr><th>20</th><td>4</td><td>5</td><td>6</td></tr>
+        <tr><th>30</th><td>7</td><td>8</td><td>9</td></tr>
+      </tbody>
+    `;
+    document.body.appendChild(tbl);
+    return tbl;
+  }
+
+  it('creates both axis sliders and interpolates on a rowspan-corner table', () => {
+    const tbl = bannerTable();
+    const rowCount = tbl.rows.length;
+    const rowSlider = addSlider(tbl, 'row');
+    const colSlider = addSlider(tbl, 'col');
+    expect(getSliders(tbl).length).toBe(2);
+    // Injection added a col-slider row and per-row/header slots.
+    expect(tbl.querySelectorAll('[data-gs-injected]').length).toBeGreaterThan(0);
+    rowSlider.setPosition(15); // between speeds 10 and 20
+    colSlider.setPosition(25); // between lengths 20 and 30
+    const readout = colSlider.handle.readoutInterpolated.textContent;
+    expect(readout).not.toBe('—');
+    expect(readout).not.toBe('');
+    removeAllSliders(tbl);
+    expect(getSliders(tbl).length).toBe(0);
+    // Injection tears down cleanly even though the row-slider header cell was
+    // inserted into the banner row spanning the whole header block: no injected
+    // scaffolding remains and the original row count is restored.
+    expect(tbl.querySelectorAll('[data-gs-injected]').length).toBe(0);
+    expect(tbl.rows.length).toBe(rowCount);
+  });
 });
 
 describe('addSlider', () => {

--- a/src/enrichments/slider-injection.ts
+++ b/src/enrichments/slider-injection.ts
@@ -13,8 +13,9 @@ import type { EquationSnapshot } from './equation-panel';
 import {
   gridRows,
   bodyRows,
-  headerRow as gridHeaderRow,
+  headerRows as gridHeaderRows,
   sourceCells,
+  dataHeaderCells,
   cellValue,
 } from '../core/table-grid';
 
@@ -68,9 +69,10 @@ function cellText(cell: HTMLTableCellElement): string {
 
 export function readRawAxisHeaders(table: HTMLTableElement, axis: Axis): string[] {
   if (axis === 'col') {
-    const header = gridHeaderRow(table);
-    if (!header) return [];
-    return sourceCells(header).slice(1).map(cellText);
+    // Occupancy-aware read of the leaf column headers: robust to a merged
+    // banner row above the numeric headers and to a rowspan corner label that
+    // shifts the leaf cells right (spec: merged-header interpolation).
+    return dataHeaderCells(table).map(cellText);
   }
   // axis === 'row'
   return bodyRows(table)
@@ -237,10 +239,13 @@ export function ensureTopRow(ctx: TableContext): HTMLTableRowElement {
   return tr;
 }
 
-function buildRowHeaderCell(): HTMLTableCellElement {
+function buildRowHeaderCell(headerRowSpan: number): HTMLTableCellElement {
   const headerCell = document.createElement('th');
   headerCell.setAttribute('data-gs-injected', '');
   headerCell.setAttribute('data-gs-row-header', '');
+  // Span the whole header block so the injected gutter column lines up with the
+  // body when the header has a merged banner row above the leaf headers.
+  headerCell.rowSpan = Math.max(1, headerRowSpan);
   headerCell.style.padding = '6px';
   headerCell.style.verticalAlign = 'middle';
   headerCell.style.textAlign = 'center';
@@ -262,10 +267,13 @@ function buildRowSliderCell(rowSpan: number): HTMLTableCellElement {
 export function ensureRowSliderSlot(ctx: TableContext): HTMLTableCellElement {
   if (ctx.rowSliderCell) return ctx.rowSliderCell;
 
-  const headerRow = gridHeaderRow(ctx.table);
+  const headerBlock = gridHeaderRows(ctx.table);
+  const headerRow = headerBlock[0];
   if (!headerRow) throw new Error('No original header row found');
 
-  const headerCell = buildRowHeaderCell();
+  // Insert into the TOP header row and span the whole header block; for a plain
+  // single-row header this is the header row with rowSpan 1 (unchanged).
+  const headerCell = buildRowHeaderCell(headerBlock.length);
   headerRow.insertBefore(headerCell, headerRow.firstChild);
 
   const cell = buildRowSliderCell(ctx.dataRowCount);

--- a/src/ui/__tests__/toggle-injector.banner-header.test.ts
+++ b/src/ui/__tests__/toggle-injector.banner-header.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Merged-header interpolation: a table with a banner/grouping header row (speed
+ * vs length matrix) must still be recognised as suitable and offer the slider
+ * (interpolation) enrichment through the real activation path.
+ *
+ * Two author permutations are covered:
+ *   1. A full-width `<th colspan="N">` banner above the numeric column headers;
+ *      the leaf header row carries the "Speed Knots" corner + length headers.
+ *   2. A `<th rowspan="2">Speed Knots</th>` corner beside a `<th colspan="N">`
+ *      banner; the leaf header row is ALL length headers (no corner cell), with
+ *      its cells shifted right by the rowspan.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { injectToggle, activateToggle, deactivateToggle } from '../toggle-injector';
+import { setPageConfig, setVisitorOverride } from '../../core/enabled-set-state';
+import { removeAllSliders } from '../../enrichments/slider';
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  setVisitorOverride(undefined);
+  setPageConfig({ enrichments: undefined, showToggleUi: false, tables: [] });
+});
+
+afterEach(() => {
+  const t = document.querySelector('table');
+  if (t) removeAllSliders(t);
+});
+
+function bannerColspanTable(): HTMLTableElement {
+  const t = document.createElement('table');
+  t.id = 'perm1';
+  t.innerHTML = `
+    <thead>
+      <tr><th colspan="4">Length Overall (m)</th></tr>
+      <tr><th>Speed Knots</th><th>10</th><th>20</th><th>30</th></tr>
+    </thead>
+    <tbody>
+      <tr><th>10</th><td>1</td><td>2</td><td>3</td></tr>
+      <tr><th>20</th><td>4</td><td>5</td><td>6</td></tr>
+      <tr><th>30</th><td>7</td><td>8</td><td>9</td></tr>
+    </tbody>`;
+  document.body.appendChild(t);
+  return t;
+}
+
+function rowspanCornerTable(): HTMLTableElement {
+  const t = document.createElement('table');
+  t.id = 'perm2';
+  t.innerHTML = `
+    <thead>
+      <tr><th rowspan="2">Speed Knots</th><th colspan="3">Length Overall (m)</th></tr>
+      <tr><th>10</th><th>20</th><th>30</th></tr>
+    </thead>
+    <tbody>
+      <tr><th>10</th><td>1</td><td>2</td><td>3</td></tr>
+      <tr><th>20</th><td>4</td><td>5</td><td>6</td></tr>
+      <tr><th>30</th><td>7</td><td>8</td><td>9</td></tr>
+    </tbody>`;
+  document.body.appendChild(t);
+  return t;
+}
+
+function sliderLozenge(t: HTMLTableElement): HTMLElement | null {
+  return t.querySelector('[data-gs-lozenge-id="sliders"]');
+}
+
+describe('interpolation on merged-header tables', () => {
+  it('offers the slider lozenge for a full-width banner header (permutation 1)', () => {
+    const t = bannerColspanTable();
+    injectToggle(t);
+    activateToggle(t);
+    const slider = sliderLozenge(t);
+    expect(slider).not.toBeNull();
+    // Enabled (not the "no numeric axis" disabled state).
+    expect(slider!.getAttribute('aria-disabled')).not.toBe('true');
+  });
+
+  it('offers the slider lozenge for a rowspan corner + banner header (permutation 2)', () => {
+    const t = rowspanCornerTable();
+    injectToggle(t);
+    activateToggle(t);
+    const slider = sliderLozenge(t);
+    expect(slider).not.toBeNull();
+    expect(slider!.getAttribute('aria-disabled')).not.toBe('true');
+  });
+
+  it('activate → deactivate restores byte-identical markup (INV-4)', () => {
+    const t = rowspanCornerTable();
+    injectToggle(t);
+    const baseline = t.innerHTML;
+    activateToggle(t);
+    deactivateToggle(t);
+    expect(t.innerHTML).toBe(baseline);
+  });
+});

--- a/src/ui/header-utils.ts
+++ b/src/ui/header-utils.ts
@@ -37,6 +37,8 @@ import {
   columnCells,
   cellValue,
   logicalColIndexOf,
+  headerRows,
+  sourceHeaderColumns,
 } from '../core/table-grid';
 import { isTwinTable } from '../core/twin-grid';
 import {
@@ -65,9 +67,19 @@ export function injectPlusIcons(table: HTMLTableElement, columnTypes: ColumnType
   ensureRowVisibilityStyles();
   ensureVirtualColumnStyles();
 
-  const rows = gridRows(table);
-  const headerRow = rows[0];
-  if (!headerRow) return;
+  // Multi-row (banner) header: place per-column lozenges on the leaf header
+  // cells resolved by logical column (occupancy-aware over colspan + rowspan),
+  // and row lozenges on the body rows only — the banner/grouping rows carry no
+  // per-column affordances. A plain single-row header keeps the original path
+  // (which also covers virtual columns and author colspan headers unchanged).
+  const multiRowHeader = headerRows(table).length > 1;
+  const headerCells = multiRowHeader
+    ? sourceHeaderColumns(table)
+    : (() => {
+        const h = gridRows(table)[0];
+        return h ? gridCells(h) : [];
+      })();
+  if (!headerCells.length) return;
 
   // Twin (grouped) tables (spec 016): the single-row-header addressing behind
   // the per-column / per-row passes mis-places lozenges on the label columns and
@@ -76,12 +88,12 @@ export function injectPlusIcons(table: HTMLTableElement, columnTypes: ColumnType
   // which carries the twin-aware slider toggle; the mis-placed H/# are not
   // offered until those enrichments learn the group structure.
   if (isTwinTable(table)) {
-    const corner = gridCells(headerRow)[0];
+    const corner = headerCells[0];
     if (corner) addLozengesToHeader(table, corner, 'table', 0);
     return;
   }
 
-  gridCells(headerRow).forEach((cell, colIndex) => {
+  headerCells.forEach((cell, colIndex) => {
     const isTopLeftCell = colIndex === 0;
     const type = columnTypes[colIndex];
     if (type === 'numeric' || type === 'categorical') {
@@ -89,8 +101,11 @@ export function injectPlusIcons(table: HTMLTableElement, columnTypes: ColumnType
     }
   });
 
-  for (let i = 1; i < rows.length; i++) {
-    const cells = gridCells(rows[i]);
+  const rowLozengeRows = multiRowHeader
+    ? bodyRows(table)
+    : gridRows(table).slice(1);
+  for (const row of rowLozengeRows) {
+    const cells = gridCells(row);
     if (!cells.length) continue;
     addLozengesToHeader(table, cells[0], 'row', 0);
   }

--- a/src/ui/toggle-injector.ts
+++ b/src/ui/toggle-injector.ts
@@ -15,6 +15,8 @@ import {
   cellValue,
   logicalColIndexOf,
   logicalRowIndexOf,
+  headerRows,
+  sourceColumnMatrix,
 } from '../core/table-grid';
 import { onVisibleRowsChange, visibleBodyRows } from '../utils/visible-rows';
 import { StatisticsPopup } from './statistics-popup';
@@ -443,9 +445,14 @@ export function activateToggle(table: HTMLTableElement): void {
   // spec 014). Using raw textContent here would let an annotated numeric cell
   // ("1200" + note) read as non-numeric and suppress a column's lozenges
   // (spec 013: scaffold/UI is never the logical grid).
-  const rows = Array.from(table.rows)
-    .filter(row => !row.hasAttribute('data-gs-injected'))
-    .map(row => Array.from(row.cells).map(cell => cellValue(cell)));
+  // A multi-row (banner) header is flattened by logical column so a merged
+  // banner / rowspan corner doesn't collapse the detected column count; a plain
+  // header keeps the raw per-cell read (which also covers virtual columns).
+  const rows = headerRows(table).length > 1
+    ? sourceColumnMatrix(table)
+    : Array.from(table.rows)
+        .filter(row => !row.hasAttribute('data-gs-injected'))
+        .map(row => Array.from(row.cells).map(cell => cellValue(cell)));
   const { columnTypes } = analyzeTable(rows);
   // Cache column types for the toggle-panel refresh path (spec 012 R-10).
   setColumnTypes(table, columnTypes);


### PR DESCRIPTION
## Summary

Speed-vs-length matrix tables commonly draw a **merged banner** above the numeric column headers. Two author permutations are now supported:

1. **Full-width banner** — a single `<th colspan="N">Length Overall (m)</th>` row above the `Speed Knots | 10 | 20 | …` header row.
2. **Rowspan corner** — a `<th rowspan="2">Speed Knots</th>` corner beside a `<th colspan="N">` banner, with the numeric length headers on the leaf row below.

Previously the canonical addressing layer treated the **first** header row as *the* column header. The banner (or the collapsed column count it produced) hid the numeric axis, so the table read as **not suitable** and the interpolation (slider) enrichment was never offered — exactly the "extra header cell will probably prevent that" case reported.

## What changed

Header resolution now peels off leading banner/grouping rows and returns the **leaf** column-header row that aligns 1:1 with the data columns. A new occupancy-aware (colspan **+** rowspan) column reader handles the rowspan corner, which shifts the leaf cells right. The fix threads through every consumer of the header model:

- **`core/table-grid.ts`** — `resolveHeader` (banner peel) + `headerRows`, `sourceHeaderColumns`, `dataHeaderCells`, `sourceColumnMatrix`.
- **`core/type-detection.ts` / `ui/toggle-injector.ts`** — flatten a multi-row header by logical column so suitability + column typing see the real numeric columns instead of a collapsed banner.
- **`ui/header-utils.ts`** — place per-column lozenges on the leaf headers, the corner slider lozenge on the true corner, and row lozenges on the body rows.
- **`enrichments/slider-injection.ts`** — read axis headers via `dataHeaderCells`; inject the row-slider header cell into the top header row spanning the whole block so the gutter lines up with the body.

Every banner-aware branch is gated on `headerRows(table).length > 1`, so **single-row-header tables are byte-identical** — no behaviour change for the common case.

## Testing

- `src/core/__tests__/table-grid.test.ts` — leaf-row resolution + `dataHeaderCells` for both permutations, no-`<thead>` banner, and a plain single-row equivalence check.
- `src/enrichments/__tests__/slider.test.ts` — `buildAxisBinding` for both permutations, end-to-end dual-axis slider creation + interpolation on a rowspan-corner table, and clean injection teardown.
- `src/ui/__tests__/toggle-injector.banner-header.test.ts` — drives the real activation path and asserts the enabled **slider lozenge** appears for both permutations, plus byte-identical activate→deactivate teardown.

Full jsdom unit suite: **731 passing** (94 files). `tsc --noEmit` clean; `vite build` clean. The Storybook browser project + Playwright e2e couldn't run in this environment (Playwright browser-build version mismatch), so those weren't exercised here.

## Notes / follow-ups

- The lozenge-mount fix places the corner slider affordance correctly; broader per-column sort/filter/heatmap behaviour on multi-row-header tables is offered but not exhaustively re-validated for exotic combinations (e.g. banner header **+** virtual columns, which fall back to source-only column typing).
- A demo page for the merged-header pattern could be added under `demo/` if useful for visual verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvweKwJZVqe5rWL8bF6ogS

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvweKwJZVqe5rWL8bF6ogS)_